### PR TITLE
Generate simple object without expect/actual if there's no targetConfigs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,58 @@ Rather I'd like to do it once.
 
 ### Gradle Configuration
 
+#### Simple configuration
+
+```gradle
+buildScript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50'
+        classpath 'com.codingfeline.buildkonfig:buildkonfig-gradle-plugin:latest_version'
+    }
+}
+
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'com.codingfeline.buildkonfig'
+
+kotlin {
+    // your target config...
+    android()
+    iosX64('ios')
+}
+
+buildkonfig {
+    packageName = 'com.example.app'
+
+    defaultConfigs {
+        buildConfigField 'STRING', 'name', 'value'
+    }
+}
+```
+- `packageName` Set the package name where BuildKonfig is being placed. **Required**.
+- `defaultConfigs` Set values which you want to have in common. **Required**.
+
+To generate BuildKonfig files, run `generateBuildKonfig` task.  
+This task will be automatically run upon execution of kotlin compile tasks.
+
+Above configuration will generate following simple object.
+
+```kotlin
+// commonMain
+package com.example.app
+
+internal object BuildKonfig {
+    val name: String = "value"
+}
+```
+
+#### Configuring `target` dependent values
+
+If you want to change value depending on your targets, you can use `targetConfigs` to define target dependent values.
+
+
 ```gradle
 buildScript {
     repositories {
@@ -87,9 +139,6 @@ buildkonfig {
 - `defaultConfigs` Set values which you want to have in common. **Required**.
 - `targetConfigs` Set target specific values as closure. You can overwrite values specified in `defaultConfigs`.
 - `buildConfigField(String type, String name, String value)` Add new value or overwrite existing one.
-
-To generate BuildKonfig files, run `generateBuildKonfig` task.  
-This task will be automatically run upon execution of kotlin compile tasks.
 
 Above configuration will generate following codes.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
         google()
         jcenter()
         gradlePluginPortal()
-        maven { url = uri( "https://dl.bintray.com/kotlin/kotlinx") }
+        maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
         maven { url = uri("https://dl.bintray.com/kotlin/kotlin-eap") }
         maven { url = uri("https://dl.bintray.com/jetbrains/kotlin-native-dependencies") }
     }

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironment.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironment.kt
@@ -1,6 +1,7 @@
 package com.codingfeline.buildkonfig.compiler
 
 import com.codingfeline.buildkonfig.compiler.generator.BuildKonfigCompiler
+import com.codingfeline.buildkonfig.compiler.generator.FileAppender
 import java.io.File
 
 class BuildKonfigEnvironment(
@@ -24,6 +25,31 @@ class BuildKonfigEnvironment(
             return@writer file.writer()
         }
 
+        if (data.targetConfigs.isEmpty()) {
+            compileCommonObject(data, writer, logger)
+        } else {
+            compileExpectActual(data, writer, logger)
+        }
+
+        return if (errors.isEmpty()) {
+            CompilationStatus.Success
+        } else {
+            CompilationStatus.Failure(errors)
+        }
+    }
+
+    private fun compileCommonObject(data: BuildKonfigData, writer: FileAppender, logger: Logger): List<String> {
+        val errors = mutableListOf<String>()
+        try {
+            BuildKonfigCompiler.compileCommonObject(data.packageName, data.commonConfig, writer, logger)
+        } catch (e: Throwable) {
+            e.message?.let { errors.add(it) }
+        }
+        return errors
+    }
+
+    private fun compileExpectActual(data: BuildKonfigData, writer: FileAppender, logger: Logger): List<String> {
+        val errors = mutableListOf<String>()
         try {
             BuildKonfigCompiler.compileCommon(data.packageName, data.commonConfig, writer, logger)
         } catch (e: Throwable) {
@@ -37,11 +63,6 @@ class BuildKonfigEnvironment(
                 e.message?.let { errors.add(it) }
             }
         }
-
-        return if (errors.isEmpty()) {
-            CompilationStatus.Success
-        } else {
-            CompilationStatus.Failure(errors)
-        }
+        return errors
     }
 }

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigGenerator.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigGenerator.kt
@@ -31,6 +31,28 @@ abstract class BuildKonfigGenerator(
     abstract fun generateProp(fieldSpec: FieldSpec): PropertySpec
 
     companion object {
+        /**
+         * Generate common object
+         */
+        fun ofCommonObject(file: TargetConfigFile, logger: Logger): BuildKonfigGenerator {
+            return object : BuildKonfigGenerator(
+                file = file,
+                objectModifiers = emptyArray(),
+                propertyModifiers = emptyArray(),
+                logger = logger
+            ) {
+                override fun generateProp(fieldSpec: FieldSpec): PropertySpec {
+                    return PropertySpec.builder(fieldSpec.name, fieldSpec.type.typeName)
+                        .initializer(fieldSpec.type.template, fieldSpec.value)
+                        .addModifiers(*propertyModifiers)
+                        .build()
+                }
+            }
+        }
+
+        /**
+         * Generate common `expect` object
+         */
         fun ofCommon(file: TargetConfigFile, logger: Logger): BuildKonfigGenerator {
             return object : BuildKonfigGenerator(
                 file = file,
@@ -46,6 +68,9 @@ abstract class BuildKonfigGenerator(
             }
         }
 
+        /**
+         * Generate target `actual` object
+         */
         fun ofTarget(file: TargetConfigFile, logger: Logger): BuildKonfigGenerator {
             return object : BuildKonfigGenerator(
                 file = file,

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
@@ -64,6 +64,62 @@ class BuildKonfigPluginFlavorTest {
     }
 
     @Test
+    fun `common object should be generated if there is no targetConfigs`() {
+        buildFile.writeText(
+            """
+            |$buildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.example"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'value', 'defaultValue'
+            |   }
+            |}
+            |$buildFileMPPConfig
+        """.trimMargin()
+        )
+
+        val buildDir = File(projectDir.root, "build/buildkonfig")
+        buildDir.deleteRecursively()
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        val result = runner
+            .withArguments("generateBuildKonfig", "--stacktrace")
+            .build()
+
+        Truth.assertThat(result.output)
+            .contains("BUILD SUCCESSFUL")
+
+        val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        Truth.assertThat(commonResult.readText())
+            .isEqualTo(
+                """
+                |package com.example
+                |
+                |import kotlin.String
+                |
+                |internal object BuildKonfig {
+                |  val value: String = "defaultValue"
+                |}
+                |
+            """.trimMargin()
+            )
+
+        val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
+        Truth.assertThat(jvmResult.exists()).isFalse()
+
+        val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
+        Truth.assertThat(jsResult.exists()).isFalse()
+
+        val iosResult = File(buildDir, "iosMain/com/example/BuildKonfig.kt")
+        Truth.assertThat(iosResult.exists()).isFalse()
+    }
+
+    @Test
     fun `flavor can be obtained from gradle properties file`() {
         buildFile.writeText(
             """
@@ -100,17 +156,18 @@ class BuildKonfigPluginFlavorTest {
         Truth.assertThat(result.output)
             .contains("BUILD SUCCESSFUL")
 
+        val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        Truth.assertThat(commonResult.readText())
+            .contains("val value: String = \"devDefaultValue\"")
+
         val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jvmResult.readText())
-            .contains("devDefaultValue")
+        Truth.assertThat(jvmResult.exists()).isFalse()
 
         val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jsResult.readText())
-            .contains("devDefaultValue")
+        Truth.assertThat(jsResult.exists()).isFalse()
 
         val iosResult = File(buildDir, "iosMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(iosResult.readText())
-            .contains("devDefaultValue")
+        Truth.assertThat(iosResult.exists()).isFalse()
     }
 
     @Test
@@ -153,17 +210,18 @@ class BuildKonfigPluginFlavorTest {
         Truth.assertThat(result.output)
             .contains("BUILD SUCCESSFUL")
 
+        val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        Truth.assertThat(commonResult.readText())
+            .contains("val value: String = \"releaseDefaultValue\"")
+
         val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jvmResult.readText())
-            .contains("releaseDefaultValue")
+        Truth.assertThat(jvmResult.exists()).isFalse()
 
         val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jsResult.readText())
-            .contains("releaseDefaultValue")
+        Truth.assertThat(jsResult.exists()).isFalse()
 
         val iosResult = File(buildDir, "iosMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(iosResult.readText())
-            .contains("releaseDefaultValue")
+        Truth.assertThat(iosResult.exists()).isFalse()
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 #
 GROUP=com.codingfeline.buildkonfig
-VERSION_NAME=0.4.0-SNAPSHOT
+VERSION_NAME=0.3.5-SNAPSHOT
 #
 POM_URL=https://github.com/yshrsmz/BuildKonfig/
 POM_SCM_URL=https://github.com/yshrsmz/BuildKonfig/


### PR DESCRIPTION
#17 

Ok I reconsidered the issue(#17) and changed my mind.

When I think which is simpler and which is more advanced, obviously "common object" is simpler and the current "expect/actual object" is more advanced/complex.

So I thought the new "common object" should be the default behavior, and the current "expect/actual object" should be an advanced option.

BuildKonfig now generates

- common single object if there's no `targetConfigs` defined.
- `expect` object in commonMain, and `actual` object in each target sourceSets if there's `targetConfigs`.(the current behavior)