### PR TITLE
Add configurable object name

### DIFF
--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigData.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigData.kt
@@ -2,6 +2,7 @@ package com.codingfeline.buildkonfig.compiler
 
 data class BuildKonfigData(
     val packageName: String,
+    val objectName: String,
     // filed specs for common source set
     val commonConfig: TargetConfigFile,
     // field specs for target source set

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironment.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironment.kt
@@ -41,7 +41,7 @@ class BuildKonfigEnvironment(
     private fun compileCommonObject(data: BuildKonfigData, writer: FileAppender, logger: Logger): List<String> {
         val errors = mutableListOf<String>()
         try {
-            BuildKonfigCompiler.compileCommonObject(data.packageName, data.commonConfig, writer, logger)
+            BuildKonfigCompiler.compileCommonObject(data.packageName, data.objectName, data.commonConfig, writer, logger)
         } catch (e: Throwable) {
             e.message?.let { errors.add(it) }
         }
@@ -51,14 +51,14 @@ class BuildKonfigEnvironment(
     private fun compileExpectActual(data: BuildKonfigData, writer: FileAppender, logger: Logger): List<String> {
         val errors = mutableListOf<String>()
         try {
-            BuildKonfigCompiler.compileCommon(data.packageName, data.commonConfig, writer, logger)
+            BuildKonfigCompiler.compileCommon(data.packageName, data.objectName, data.commonConfig, writer, logger)
         } catch (e: Throwable) {
             e.message?.let { errors.add(it) }
         }
 
         data.targetConfigs.forEach { config ->
             try {
-                BuildKonfigCompiler.compileTarget(data.packageName, config, writer, logger)
+                BuildKonfigCompiler.compileTarget(data.packageName, data.objectName, config, writer, logger)
             } catch (e: Throwable) {
                 e.message?.let { errors.add(it) }
             }

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/Constants.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/Constants.kt
@@ -1,5 +1,5 @@
 package com.codingfeline.buildkonfig.compiler
 
-const val KONFIG_OBJECT_NAME = "BuildKonfig"
+const val DEFAULT_KONFIG_OBJECT_NAME = "BuildKonfig"
 
 typealias Logger = (String) -> Unit

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigCompiler.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigCompiler.kt
@@ -1,6 +1,5 @@
 package com.codingfeline.buildkonfig.compiler.generator
 
-import com.codingfeline.buildkonfig.compiler.KONFIG_OBJECT_NAME
 import com.codingfeline.buildkonfig.compiler.Logger
 import com.codingfeline.buildkonfig.compiler.TargetConfigFile
 import com.squareup.kotlinpoet.FileSpec
@@ -12,55 +11,58 @@ object BuildKonfigCompiler {
 
     fun compileCommonObject(
         packageName: String,
+        objectName: String,
         configFile: TargetConfigFile,
         output: FileAppender,
         logger: Logger
     ) {
         val outputDirectory = getOutputDirectory(configFile, packageName)
 
-        val konfigType = BuildKonfigGenerator.ofCommonObject(configFile, logger).generateType()
+        val konfigType = BuildKonfigGenerator.ofCommonObject(configFile, logger).generateType(objectName)
 
-        FileSpec.builder(packageName, KONFIG_OBJECT_NAME)
+        FileSpec.builder(packageName, objectName)
             .apply {
                 addType(konfigType)
             }
             .build()
-            .writeToAndClose(output("$outputDirectory/$KONFIG_OBJECT_NAME.kt"))
+            .writeToAndClose(output("$outputDirectory/$objectName.kt"))
     }
 
     fun compileCommon(
         packageName: String,
+        objectName: String,
         configFile: TargetConfigFile,
         output: FileAppender,
         logger: Logger
     ) {
         val outputDirectory = getOutputDirectory(configFile, packageName)
 
-        val konfigType = BuildKonfigGenerator.ofCommon(configFile, logger).generateType()
+        val konfigType = BuildKonfigGenerator.ofCommon(configFile, logger).generateType(objectName)
 
-        FileSpec.builder(packageName, KONFIG_OBJECT_NAME)
+        FileSpec.builder(packageName, objectName)
             .apply {
                 addType(konfigType)
             }
             .build()
-            .writeToAndClose(output("$outputDirectory/$KONFIG_OBJECT_NAME.kt"))
+            .writeToAndClose(output("$outputDirectory/$objectName.kt"))
     }
 
     fun compileTarget(
         packageName: String,
+        objectName: String,
         configFile: TargetConfigFile,
         output: FileAppender,
         logger: Logger
     ) {
         val outputDirectory = getOutputDirectory(configFile, packageName)
-        val konfigType = BuildKonfigGenerator.ofTarget(configFile, logger).generateType()
+        val konfigType = BuildKonfigGenerator.ofTarget(configFile, logger).generateType(objectName)
 
-        FileSpec.builder(packageName, KONFIG_OBJECT_NAME)
+        FileSpec.builder(packageName, objectName)
             .apply {
                 addType(konfigType)
             }
             .build()
-            .writeToAndClose(output("$outputDirectory/$KONFIG_OBJECT_NAME.kt"))
+            .writeToAndClose(output("$outputDirectory/$objectName.kt"))
     }
 
     private fun FileSpec.writeToAndClose(appendable: Appendable) {

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigGenerator.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigGenerator.kt
@@ -1,7 +1,6 @@
 package com.codingfeline.buildkonfig.compiler.generator
 
 import com.codingfeline.buildkonfig.compiler.FieldSpec
-import com.codingfeline.buildkonfig.compiler.KONFIG_OBJECT_NAME
 import com.codingfeline.buildkonfig.compiler.Logger
 import com.codingfeline.buildkonfig.compiler.TargetConfigFile
 import com.squareup.kotlinpoet.KModifier
@@ -15,8 +14,8 @@ abstract class BuildKonfigGenerator(
     val logger: Logger
 ) {
 
-    fun generateType(): TypeSpec {
-        val obj = TypeSpec.objectBuilder(KONFIG_OBJECT_NAME)
+    fun generateType(objectName: String): TypeSpec {
+        val obj = TypeSpec.objectBuilder(objectName)
             .addModifiers(KModifier.INTERNAL)
             .addModifiers(*objectModifiers)
 

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigExtension.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigExtension.kt
@@ -1,5 +1,6 @@
 package com.codingfeline.buildkonfig.gradle
 
+import com.codingfeline.buildkonfig.compiler.DEFAULT_KONFIG_OBJECT_NAME
 import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
@@ -12,6 +13,7 @@ open class BuildKonfigExtension(
     private val configFactory = TargetConfigFactory(project.objects, project.logger)
 
     var packageName: String? = null
+    var objectName: String = DEFAULT_KONFIG_OBJECT_NAME
 
     val defaultConfigs = mutableMapOf<String, TargetConfigDsl>()
     val targetConfigs = mutableMapOf<String, NamedDomainObjectContainer<TargetConfigDsl>>()

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -64,6 +64,7 @@ open class BuildKonfigPlugin : Plugin<Project> {
 
             val task = p.tasks.register("generateBuildKonfig", BuildKonfigTask::class.java) {
                 it.packageName = requireNotNull(extension.packageName) { "packageName must be provided" }
+                it.objectName = extension.objectName
                 it.commonOutputDirectory = commonOutputDirectory
                 it.outputDirectories = outputDirectoryMap
                 it.extension = extension

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -64,6 +64,7 @@ open class BuildKonfigPlugin : Plugin<Project> {
 
             val task = p.tasks.register("generateBuildKonfig", BuildKonfigTask::class.java) {
                 it.packageName = requireNotNull(extension.packageName) { "packageName must be provided" }
+                require(extension.objectName.isNotBlank()) { "objectName must not be blank" }
                 it.objectName = extension.objectName
                 it.commonOutputDirectory = commonOutputDirectory
                 it.outputDirectories = outputDirectoryMap

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
@@ -29,6 +29,9 @@ open class BuildKonfigTask : DefaultTask() {
     @Input
     lateinit var packageName: String
 
+    @Input
+    lateinit var objectName: String
+
     @get:Input
     val targetNames: Set<TargetName>
         get() = outputDirectories.keys
@@ -86,6 +89,7 @@ open class BuildKonfigTask : DefaultTask() {
 
         val data = BuildKonfigData(
             packageName = packageName,
+            objectName = objectName,
             commonConfig = TargetConfigFile(KotlinPlatformType.common.name, commonOutputDirectory, defaultConfig),
             targetConfigs = mergedConfigFiles
         )

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
@@ -573,4 +573,62 @@ class BuildKonfigPluginFlavorTest {
             contains("object AwesomeConfig")
         }
     }
+
+    @Test
+    fun `The generated target objects use the given objectName`() {
+        buildFile.writeText(
+            """
+            |$buildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.example"
+            |   objectName = "AwesomeConfig"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'value', 'defaultValue'
+            |   }
+            |   targetConfigs {
+            |       js {
+            |         buildConfigField 'STRING', 'value', 'jsValue'
+            |       }
+            |   }
+            |}
+            |$buildFileMPPConfig
+        """.trimMargin()
+        )
+
+        val propertyFile = projectDir.newFile("gradle.properties")
+        propertyFile.writeText("buildkonfig.flavor=dev")
+
+        val buildDir = File(projectDir.root, "build/buildkonfig")
+        buildDir.deleteRecursively()
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        val result = runner
+            .withArguments("generateBuildKonfig", "--stacktrace")
+            .build()
+
+        Truth.assertThat(result.output)
+            .contains("BUILD SUCCESSFUL")
+
+        val commonResult = File(buildDir, "commonMain/com/example/AwesomeConfig.kt")
+        Truth.assertThat(commonResult.readText()).apply {
+            contains("object AwesomeConfig")
+        }
+
+        val jsResult = File(buildDir, "jsMain/com/example/AwesomeConfig.kt")
+        Truth.assertThat(jsResult.readText())
+            .contains("object AwesomeConfig")
+
+        val jvmResult = File(buildDir, "jvmMain/com/example/AwesomeConfig.kt")
+        Truth.assertThat(jvmResult.readText())
+            .contains("object AwesomeConfig")
+
+        val iosResult = File(buildDir, "iosMain/com/example/AwesomeConfig.kt")
+        Truth.assertThat(iosResult.readText())
+            .contains("object AwesomeConfig")
+    }
 }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
@@ -532,4 +532,45 @@ class BuildKonfigPluginFlavorTest {
         Truth.assertThat(iosResult.readText())
             .contains("defaultValue")
     }
+
+    @Test
+    fun `The generated object uses the given objectName`() {
+        buildFile.writeText(
+            """
+            |$buildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.example"
+            |   objectName = "AwesomeConfig"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'value', 'defaultValue'
+            |   }
+            |}
+            |$buildFileMPPConfig
+        """.trimMargin()
+        )
+
+        val propertyFile = projectDir.newFile("gradle.properties")
+        propertyFile.writeText("buildkonfig.flavor=dev")
+
+        val buildDir = File(projectDir.root, "build/buildkonfig")
+        buildDir.deleteRecursively()
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        val result = runner
+            .withArguments("generateBuildKonfig", "--stacktrace")
+            .build()
+
+        Truth.assertThat(result.output)
+            .contains("BUILD SUCCESSFUL")
+
+        val commonResult = File(buildDir, "commonMain/com/example/AwesomeConfig.kt")
+        Truth.assertThat(commonResult.readText()).apply {
+            contains("object AwesomeConfig")
+        }
+    }
 }


### PR DESCRIPTION
close #32 

The implemented API is the same as described in the issue.

```kotlin 
buildkonfig {
    packageName = 'com.example.app'
    objectName = 'AwesomeConfig'  // defaults to 'BuildKonfig'

    defaultConfigs {
        buildConfigField 'STRING', 'name', 'value'
    }
}
```