### PR TITLE
Add support for const values

### DIFF
--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/FieldSpec.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/FieldSpec.kt
@@ -9,7 +9,8 @@ data class FieldSpec(
     val name: String,
     val value: String?,
     val isTargetSpecific: Boolean = false,
-    val nullable: Boolean = false
+    val nullable: Boolean = false,
+    val const: Boolean = false,
 ) : Serializable {
 
     enum class Type(val _typeName: TypeName, val _template: String = "%L") {

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigCompiler.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigCompiler.kt
@@ -20,15 +20,10 @@ object BuildKonfigCompiler {
     ) {
         val outputDirectory = getOutputDirectory(configFile, packageName)
 
-        val konfigType = BuildKonfigGenerator.ofCommonObject(configFile, exposeObject, hasJsTarget, logger)
-            .generateType(objectName)
+        val konfigFile = BuildKonfigGenerator.ofCommonObject(configFile, exposeObject, hasJsTarget, logger)
+            .generateFile(packageName, objectName)
 
-        FileSpec.builder(packageName, objectName)
-            .apply {
-                addType(konfigType)
-            }
-            .build()
-            .writeToAndClose(output("$outputDirectory/$objectName.kt"))
+        konfigFile.writeToAndClose(output("$outputDirectory/$objectName.kt"))
     }
 
     fun compileCommon(
@@ -41,14 +36,10 @@ object BuildKonfigCompiler {
     ) {
         val outputDirectory = getOutputDirectory(configFile, packageName)
 
-        val konfigType = BuildKonfigGenerator.ofCommon(configFile, exposeObject, logger).generateType(objectName)
+        val konfigFile = BuildKonfigGenerator.ofCommon(configFile, exposeObject, logger)
+            .generateFile(packageName, objectName)
 
-        FileSpec.builder(packageName, objectName)
-            .apply {
-                addType(konfigType)
-            }
-            .build()
-            .writeToAndClose(output("$outputDirectory/$objectName.kt"))
+        konfigFile.writeToAndClose(output("$outputDirectory/$objectName.kt"))
     }
 
     fun compileTarget(
@@ -60,14 +51,11 @@ object BuildKonfigCompiler {
         logger: Logger
     ) {
         val outputDirectory = getOutputDirectory(configFile, packageName)
-        val konfigType = BuildKonfigGenerator.ofTarget(configFile, exposeObject, logger).generateType(objectName)
 
-        FileSpec.builder(packageName, objectName)
-            .apply {
-                addType(konfigType)
-            }
-            .build()
-            .writeToAndClose(output("$outputDirectory/$objectName.kt"))
+        val konfigFile = BuildKonfigGenerator.ofTarget(configFile, exposeObject, logger)
+            .generateFile(packageName, objectName)
+
+        konfigFile.writeToAndClose(output("$outputDirectory/$objectName.kt"))
     }
 
     private fun FileSpec.writeToAndClose(appendable: Appendable) {

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigGenerator.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigGenerator.kt
@@ -18,16 +18,9 @@ abstract class BuildKonfigGenerator(
     val propertyModifiers: List<KModifier>,
     val logger: Logger
 ) {
-    protected var suppressConstExpect: Boolean = false
-
     fun generateFile(packageName: String, objectName: String): FileSpec {
         val builder = FileSpec.builder(packageName, objectName)
         builder.addType(generateType(objectName))
-        if (suppressConstExpect) {
-            builder.addAnnotation(AnnotationSpec.builder(ClassName("kotlin", "Suppress"))
-                .addMember("%S", "CONST_VAL_WITHOUT_INITIALIZER")
-                .build())
-        }
         return builder.build()
     }
 
@@ -94,7 +87,9 @@ abstract class BuildKonfigGenerator(
                         .addModifiers(*propertyModifiers.toTypedArray())
                     if (fieldSpec.const) {
                         spec.addModifiers(KModifier.CONST)
-                        suppressConstExpect = true
+                            .addAnnotation(AnnotationSpec.builder(ClassName("kotlin", "Suppress"))
+                            .addMember("%S", "CONST_VAL_WITHOUT_INITIALIZER")
+                            .build())
                     }
                     return spec.build()
                 }

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigGenerator.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigGenerator.kt
@@ -6,6 +6,7 @@ import com.codingfeline.buildkonfig.compiler.PlatformType
 import com.codingfeline.buildkonfig.compiler.TargetConfigFile
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
@@ -17,8 +18,20 @@ abstract class BuildKonfigGenerator(
     val propertyModifiers: List<KModifier>,
     val logger: Logger
 ) {
+    protected var suppressConstExpect: Boolean = false
 
-    fun generateType(objectName: String): TypeSpec {
+    fun generateFile(packageName: String, objectName: String): FileSpec {
+        val builder = FileSpec.builder(packageName, objectName)
+        builder.addType(generateType(objectName))
+        if (suppressConstExpect) {
+            builder.addAnnotation(AnnotationSpec.builder(ClassName("kotlin", "Suppress"))
+                .addMember("%S", "CONST_VAL_WITHOUT_INITIALIZER")
+                .build())
+        }
+        return builder.build()
+    }
+
+    private fun generateType(objectName: String): TypeSpec {
         val obj = TypeSpec.objectBuilder(objectName)
             .addModifiers(*objectModifiers.toTypedArray())
             .addAnnotations(objectAnnotations)
@@ -53,10 +66,13 @@ abstract class BuildKonfigGenerator(
                 logger = logger
             ) {
                 override fun generateProp(fieldSpec: FieldSpec): PropertySpec {
-                    return PropertySpec.builder(fieldSpec.name, fieldSpec.typeName)
+                    val spec = PropertySpec.builder(fieldSpec.name, fieldSpec.typeName)
                         .initializer(fieldSpec.template, fieldSpec.value)
                         .addModifiers(*propertyModifiers.toTypedArray())
-                        .build()
+                    if (fieldSpec.const) {
+                        spec.addModifiers(KModifier.CONST)
+                    }
+                    return spec.build()
                 }
             }
         }
@@ -74,9 +90,13 @@ abstract class BuildKonfigGenerator(
                 logger = logger
             ) {
                 override fun generateProp(fieldSpec: FieldSpec): PropertySpec {
-                    return PropertySpec.builder(fieldSpec.name, fieldSpec.typeName)
+                    val spec = PropertySpec.builder(fieldSpec.name, fieldSpec.typeName)
                         .addModifiers(*propertyModifiers.toTypedArray())
-                        .build()
+                    if (fieldSpec.const) {
+                        spec.addModifiers(KModifier.CONST)
+                        suppressConstExpect = true
+                    }
+                    return spec.build()
                 }
             }
         }
@@ -104,6 +124,10 @@ abstract class BuildKonfigGenerator(
 
                     if (!fieldSpec.isTargetSpecific) {
                         spec.addModifiers(*propertyModifiers.toTypedArray())
+                    }
+
+                    if (fieldSpec.const) {
+                        spec.addModifiers(KModifier.CONST)
                     }
 
                     return spec.build()

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/TargetConfigDsl.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/TargetConfigDsl.kt
@@ -15,35 +15,44 @@ open class TargetConfigDsl @Inject constructor(
         const val serialVersionUID = 1L
     }
 
+    private fun registerField(field: FieldSpec) {
+        val name = field.name
+        val alreadyPresent = fieldSpecs[name]
+
+        if (alreadyPresent != null) {
+            logger.info("TargetConfig: buildConfigField '$name' is being replaced: ${alreadyPresent.value} -> ${field.value}")
+        }
+
+        fieldSpecs[name] = field
+    }
+
     @Suppress("unused")
     fun buildConfigField(
         type: FieldSpec.Type,
         name: String,
         value: String
-    ) {
-
-        val alreadyPresent = fieldSpecs[name]
-
-        if (alreadyPresent != null) {
-            logger.info("TargetConfig: buildConfigField '$name' is being replaced: ${alreadyPresent.value} -> $value")
-        }
-        fieldSpecs[name] = FieldSpec(type, name, value)
-    }
+    ) = registerField(FieldSpec(type, name, value))
 
     @Suppress("unused")
     fun buildConfigNullableField(
         type: FieldSpec.Type,
         name: String,
         value: String?
-    ) {
+    ) = registerField(FieldSpec(type, name, value, nullable = true))
 
-        val alreadyPresent = fieldSpecs[name]
+    @Suppress("unused")
+    fun buildConfigConstField(
+        type: FieldSpec.Type,
+        name: String,
+        value: String
+    ) = registerField(FieldSpec(type, name, value, const = true))
 
-        if (alreadyPresent != null) {
-            logger.info("TargetConfig: buildConfigField '$name' is being replaced: ${alreadyPresent.value} -> $value")
-        }
-        fieldSpecs[name] = FieldSpec(type, name, value, nullable = true)
-    }
+    @Suppress("unused")
+    fun buildConfigConstNullableField(
+        type: FieldSpec.Type,
+        name: String,
+        value: String
+    ) = registerField(FieldSpec(type, name, value, nullable = true, const = true))
 
     fun toTargetConfig(): TargetConfig {
         return TargetConfig(name)

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
@@ -86,7 +86,7 @@ class BuildKonfigPluginConstFieldsTest {
 
         val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
         Truth.assertThat(commonResult.readText()).apply {
-            contains("@file:Suppress(\"CONST_VAL_WITHOUT_INITIALIZER\")")
+            contains("@Suppress(\"CONST_VAL_WITHOUT_INITIALIZER\")")
             contains("const val foo: String")
         }
 

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
@@ -1,0 +1,101 @@
+package com.codingfeline.buildkonfig.gradle
+
+import com.google.common.truth.Truth
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class BuildKonfigPluginConstFieldsTest {
+
+    @get:Rule
+    val projectDir = TemporaryFolder()
+
+    lateinit var buildFile: File
+
+    lateinit var settingFile: File
+
+    private val buildFileHeader = """
+        |plugins {
+        |    id("kotlin-multiplatform")
+        |    id("com.codingfeline.buildkonfig")
+        |}
+        |
+        |repositories {
+        |   mavenCentral()
+        |}
+        |
+    """.trimMargin()
+
+    private val buildFileMPPConfig = """
+        |kotlin {
+        |  jvm()
+        |  js(IR) {
+        |    browser()
+        |    nodejs()
+        |  }
+        |}
+    """.trimMargin()
+
+    @Before
+    fun setup() {
+        buildFile = projectDir.newFile("build.gradle.kts")
+        settingFile = projectDir.newFile("settings.gradle")
+        settingFile.writeText(settingsGradle)
+    }
+
+    @Test
+    fun `const values for expect object contains suppress annotation`() {
+        buildFile.writeText(
+            """
+            |import com.codingfeline.buildkonfig.compiler.FieldSpec.Type
+            |$buildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.example"
+            |   
+            |   defaultConfigs {
+            |       buildConfigConstField(Type.STRING, "foo", "defaultValue")
+            |   }
+            |   targetConfigs {
+            |       create("js") {
+            |           buildConfigConstField(Type.STRING, "foo", "jsValue")
+            |       }
+            |   }
+            |}
+            |
+            |$buildFileMPPConfig
+            """.trimMargin()
+        )
+
+        val buildDir = File(projectDir.root, "build/buildkonfig")
+        buildDir.deleteRecursively()
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        val result = runner
+            .withArguments("generateBuildKonfig", "--stacktrace")
+            .build()
+
+        Truth.assertThat(result.output)
+            .contains("BUILD SUCCESSFUL")
+
+        val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        Truth.assertThat(commonResult.readText()).apply {
+            contains("@file:Suppress(\"CONST_VAL_WITHOUT_INITIALIZER\")")
+            contains("const val foo: String")
+        }
+
+        val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
+        Truth.assertThat(jvmResult.readText())
+            .contains("const val foo: String = \"defaultValue\"")
+
+        val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
+        Truth.assertThat(jsResult.readText())
+            .contains("const val foo: String = \"jsValue\"")
+    }
+}


### PR DESCRIPTION
resolve #42 

Const values can be used in expect/actual objects with `@Suppress("CONST_VAL_WITHOUT_INITIALIZER")` on expect class/file, working flawlessly since Kotlin 1.3