### PR TITLE
Chore/gradle plugin 8.0.1 kotlin 1.8.21

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -19,7 +19,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Execute test cases
         run: ./gradlew test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Publish the artifacts to Maven Central
         env:

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ buildkonfig {
 <summary>Kotlin DSL</summary>
 
 ```kotlin
-import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.String
 import com.codingfeline.buildkonfig.gradle.TargetConfigDsl
 
 buildkonfig {

--- a/buildkonfig-compiler/build.gradle.kts
+++ b/buildkonfig-compiler/build.gradle.kts
@@ -36,7 +36,7 @@ tasks.create("pluginVersion") {
 afterEvaluate {
     tasks.named("compileKotlin").configure { dependsOn("pluginVersion") }
     tasks.named("dokkaHtml").configure { dependsOn("pluginVersion") }
-    tasks.named("javaSourcesJar").configure { dependsOn("pluginVersion") }
+    tasks.named("kotlinSourcesJar").configure { dependsOn("pluginVersion") }
 }
 
 tasks.compileKotlin {

--- a/buildkonfig-gradle-plugin/build.gradle.kts
+++ b/buildkonfig-gradle-plugin/build.gradle.kts
@@ -15,21 +15,17 @@ val POM_DESCRIPTION: String by project
 val POM_NAME: String by project
 
 gradlePlugin {
+    website.set(POM_URL)
+    vcsUrl.set("https://github.com/yshrsmz/BuildKonfig.git")
     plugins {
         create("buildKonfig") {
             id = "com.codingfeline.buildkonfig"
             implementationClass = "com.codingfeline.buildkonfig.gradle.BuildKonfigPlugin"
             displayName = POM_NAME
             description = POM_DESCRIPTION
+            tags.set(listOf("BuildConfig", "Kotlin", "Kotlin Multiplatform"))
         }
     }
-}
-
-pluginBundle {
-    website = POM_URL
-    vcsUrl = "https://github.com/yshrsmz/BuildKonfig.git"
-    description = POM_DESCRIPTION
-    tags = listOf("BuildConfig", "Kotlin", "Kotlin Multiplatform")
 }
 
 val fixtureClasspath by configurations.creating

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/kotlin/SourceRoots.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/kotlin/SourceRoots.kt
@@ -26,14 +26,14 @@ internal fun KotlinMultiplatformExtension.sources(): List<Source> {
                             val all = compilation.allKotlinSourceSets
                                 .filter {
                                     it.name != "${target.name}Main" &&
-                                            it.name != compilation.defaultSourceSetName
+                                            it.name != compilation.defaultSourceSet.name
                                 }
 
                             default to all
                         }
                         else -> {
                             compilation.defaultSourceSet to compilation.allKotlinSourceSets
-                                .filter { it.name != compilation.defaultSourceSetName }
+                                .filter { it.name != compilation.defaultSourceSet.name }
                         }
                     }
                     Source(

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginHMPPTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginHMPPTest.kt
@@ -39,9 +39,8 @@ class BuildKonfigPluginHMPPTest {
             .also {
                 it.writeText(
                     """
-                        kotlin.mpp.stability.nowarn=true
-                        kotlin.mpp.enableGranularSourceSetsMetadata=true
-                        kotlin.native.enableDependencyPropagation=false
+                        kotlin.mpp.androidSourceSetLayoutVersion=2
+                        kotlin.js.compiler=ir
                         """.trimMargin()
                 )
             }
@@ -84,6 +83,8 @@ class BuildKonfigPluginHMPPTest {
             |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
             |        }
             |    }
+            |    
+            |    namespace = "com.sample"
             |}
             |buildkonfig {
             |    packageName = "com.sample"
@@ -110,7 +111,7 @@ class BuildKonfigPluginHMPPTest {
             |kotlin {
             |   android('customAndroid')
             |   jvm()
-            |   js {
+            |   js(IR) {
             |    browser()
             |    nodejs()
             |   }
@@ -240,6 +241,8 @@ class BuildKonfigPluginHMPPTest {
             |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
             |        }
             |    }
+            |    
+            |    namespace = "com.sample"
             |}
             |buildkonfig {
             |    packageName = "com.sample"
@@ -442,6 +445,8 @@ class BuildKonfigPluginHMPPTest {
             |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
             |        }
             |    }
+            |    
+            |    namespace = "com.sample"
             |}
             |buildkonfig {
             |    packageName = "com.sample"

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
@@ -54,6 +54,16 @@ class BuildKonfigPluginTest {
         buildFile = projectDir.newFile("build.gradle")
         settingFile = projectDir.newFile("settings.gradle")
         settingFile.writeText(settingsGradle)
+
+        projectDir.newFile("gradle.properties")
+            .also {
+                it.writeText(
+                    """
+                        kotlin.mpp.androidSourceSetLayoutVersion=2
+                        kotlin.js.compiler=ir
+                        """.trimMargin()
+                )
+            }
     }
 
     @Test
@@ -198,6 +208,8 @@ class BuildKonfigPluginTest {
             |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
             |        }
             |    }
+            |    
+            |    namespace = "com.sample"
             |}
             |buildkonfig {
             |    packageName = "com.sample"
@@ -224,7 +236,7 @@ class BuildKonfigPluginTest {
             |kotlin {
             |   android('customAndroid')
             |   jvm()
-            |   js {
+            |   js(IR) {
             |    browser()
             |    nodejs()
             |   }
@@ -342,6 +354,8 @@ class BuildKonfigPluginTest {
             |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
             |        }
             |    }
+            |    
+            |    namespace = "com.sample"
             |}
             |buildkonfig {
             |    packageName = "com.sample"
@@ -443,6 +457,8 @@ class BuildKonfigPluginTest {
             |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
             |        }
             |    }
+            |    
+            |    namespace = "com.sample"
             |}
             |buildkonfig {
             |    packageName = "com.sample"
@@ -543,6 +559,8 @@ class BuildKonfigPluginTest {
             |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
             |        }
             |    }
+            |    
+            |    namespace = "com.sample"
             |}
             |buildkonfig {
             |    packageName = "com.sample"

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildkonfigPluginKotlinDSLTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildkonfigPluginKotlinDSLTest.kt
@@ -84,6 +84,8 @@ class BuildkonfigPluginKotlinDSLTest {
             |        minSdkVersion(21)
             |        targetSdkVersion(30)
             |    }
+            |    
+            |    namespace = "com.sample"
             |}
             """.trimMargin()
         )

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/TestUtils.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/TestUtils.kt
@@ -4,7 +4,7 @@ import org.junit.rules.TemporaryFolder
 
 val androidManifest = """
         |<?xml version="1.0" encoding="utf-8"?>
-        |<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.sample"/>
+        |<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
     """.trimMargin()
 
 fun createAndroidManifest(projectDir: TemporaryFolder, sourceSetName: String = "androidMain") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-gradle = "7.4.2"
-kotlin = "1.6.21"
+gradle = "8.0.1"
+kotlin = "1.8.21"
 dokka = "1.6.21"
 
 jvmTarget = "1.8"
@@ -11,7 +11,7 @@ junit = { module = "junit:junit", version = "4.13.2" }
 truth = { module = "com.google.truth:truth", version = "1.1.3" }
 
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-android-plugin = { module = "com.android.tools.build:gradle", version = "7.2.2" }
+android-plugin = { module = "com.android.tools.build:gradle", version = "gradle" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 gradle = "8.0.1"
 kotlin = "1.8.21"
-dokka = "1.6.21"
+dokka = "1.8.10"
 
 jvmTarget = "1.8"
 
 [libraries]
-kotlinpoet = { module = "com.squareup:kotlinpoet", version = "1.12.0" }
+kotlinpoet = { module = "com.squareup:kotlinpoet", version = "1.13.2" }
 junit = { module = "junit:junit", version = "4.13.2" }
 truth = { module = "com.google.truth:truth", version = "1.1.3" }
 
@@ -18,5 +18,5 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 versions = { id = "com.github.ben-manes.versions", version = "0.42.0" }
-pluginPublish = { id = "com.gradle.plugin-publish", version = "0.21.0" }
-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.21.0" }
+pluginPublish = { id = "com.gradle.plugin-publish", version = "1.2.0" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.25.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ junit = { module = "junit:junit", version = "4.13.2" }
 truth = { module = "com.google.truth:truth", version = "1.1.3" }
 
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-android-plugin = { module = "com.android.tools.build:gradle", version = "gradle" }
+android-plugin = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.jetbrains.kotlin.multiplatform") version "1.6.21"
+    id("org.jetbrains.kotlin.multiplatform") version "1.8.21"
     id("com.codingfeline.buildkonfig") version "+"
 }
 


### PR DESCRIPTION
Hi, I thought it would help to update gradle and kotlin version. Do you think I should upgrade also source and target compatibility? Am I missing something? I'm available for any modification.

I tried to test the PR but I receive the following error: 
> Task :buildkonfig-compiler:signMavenPublication FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':buildkonfig-compiler:signMavenPublication'.
> Cannot perform signing task ':buildkonfig-compiler:signMavenPublication' because it has no configured signatory

Should I add something to global Gradle properties?
Thanks