### PR TITLE
fix(sample): update samples for Kotlin 2.3.20 compatibility

### DIFF
--- a/sample-kts/build.gradle.kts
+++ b/sample-kts/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
     iosArm64()
     iosX64()
     iosSimulatorArm64()
-    macosX64()
+    macosArm64()
     linuxX64()
     mingwX64()
 
@@ -25,7 +25,7 @@ kotlin {
      *   - appMain
      *     - jvmMain
      *     - desktopMain
-     *       - macosX64Main
+     *       - macosArm64Main
      *       - linuxX64Main
      *       - mingwX64Main
      *   - jsCommonMain
@@ -50,7 +50,7 @@ kotlin {
             dependsOn(appMain)
         }
 
-        val macosX64Main by getting {
+        val macosArm64Main by getting {
             dependsOn(desktopMain)
         }
         val linuxX64Main by getting {
@@ -60,9 +60,7 @@ kotlin {
             dependsOn(desktopMain)
         }
 
-        val jsCommonMain by getting {
-            dependsOn(commonMain)
-        }
+        val jsCommonMain by getting {}
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -12,7 +12,7 @@ kotlin {
     iosArm64()
     iosX64()
     iosSimulatorArm64()
-    macosX64()
+    macosArm64()
     linuxX64()
     mingwX64()
 
@@ -23,7 +23,7 @@ kotlin {
      *   - appMain
      *     - jvmMain
      *     - desktopMain
-     *       - macosX64Main
+     *       - macosArm64Main
      *       - linuxX64Main
      *       - mingwX64Main
      *   - jsCommonMain
@@ -44,7 +44,7 @@ kotlin {
         desktopMain {
             dependsOn(appMain)
         }
-        macosX64Main {
+        macosArm64Main {
             dependsOn(desktopMain)
         }
         linuxX64Main {
@@ -53,9 +53,7 @@ kotlin {
         mingwX64Main {
             dependsOn(desktopMain)
         }
-        jsCommonMain {
-            dependsOn(commonMain)
-        }
+        jsCommonMain {}
     }
 }
 

--- a/sample/settings.gradle
+++ b/sample/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     includeBuild("..")
     repositories {
-        maven { url "../build/localMaven" }
+        maven { url = "../build/localMaven" }
         mavenCentral()
         google()
         gradlePluginPortal()


### PR DESCRIPTION
## Summary
- Replace deprecated `macosX64()` with `macosArm64()` in both sample projects
- Remove redundant `jsCommonMain.dependsOn(commonMain)` (auto-added by hierarchy template)
- Fix Groovy DSL assignment syntax in `sample/settings.gradle` (`url` → `url =`)

## Test plan
- [x] `./gradlew clean build` passes
- [x] `./gradlew -p sample generateBuildKonfig --warning-mode all` — no warnings
- [x] `./gradlew -p sample-kts generateBuildKonfig --warning-mode all` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)