### PR TITLE
fix: warn instead of throwing when defaultConfigs is empty

### DIFF
--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironment.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironment.kt
@@ -13,7 +13,7 @@ class BuildKonfigEnvironment(
         class Failure(val errors: List<String>) : CompilationStatus()
     }
 
-    fun generateConfigs(logger: Logger): CompilationStatus {
+    fun generateConfigs(logger: BuildKonfigLogger): CompilationStatus {
         val errors = ArrayList<String>()
 
         val writer = writer@{ fileName: String ->
@@ -38,7 +38,7 @@ class BuildKonfigEnvironment(
         }
     }
 
-    private fun compileCommonObject(data: BuildKonfigData, writer: FileAppender, logger: Logger): List<String> {
+    private fun compileCommonObject(data: BuildKonfigData, writer: FileAppender, logger: BuildKonfigLogger): List<String> {
         val errors = mutableListOf<String>()
         try {
             BuildKonfigCompiler.compileCommonObject(
@@ -56,7 +56,7 @@ class BuildKonfigEnvironment(
         return errors
     }
 
-    private fun compileExpectActual(data: BuildKonfigData, writer: FileAppender, logger: Logger): List<String> {
+    private fun compileExpectActual(data: BuildKonfigData, writer: FileAppender, logger: BuildKonfigLogger): List<String> {
         val errors = mutableListOf<String>()
         try {
             BuildKonfigCompiler.compileCommon(

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigLogger.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigLogger.kt
@@ -1,0 +1,10 @@
+package com.codingfeline.buildkonfig.compiler
+
+fun interface BuildKonfigLogger {
+    fun log(level: LogLevel, message: String)
+
+    fun info(message: String) = log(LogLevel.INFO, message)
+    fun warn(message: String) = log(LogLevel.WARN, message)
+}
+
+enum class LogLevel { INFO, WARN }

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/Constants.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/Constants.kt
@@ -1,5 +1,3 @@
 package com.codingfeline.buildkonfig.compiler
 
 const val DEFAULT_KONFIG_OBJECT_NAME = "BuildKonfig"
-
-typealias Logger = (String) -> Unit

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigCompiler.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigCompiler.kt
@@ -1,6 +1,6 @@
 package com.codingfeline.buildkonfig.compiler.generator
 
-import com.codingfeline.buildkonfig.compiler.Logger
+import com.codingfeline.buildkonfig.compiler.BuildKonfigLogger
 import com.codingfeline.buildkonfig.compiler.TargetConfigFile
 import com.squareup.kotlinpoet.FileSpec
 import java.io.Closeable
@@ -16,7 +16,7 @@ object BuildKonfigCompiler {
         configFile: TargetConfigFile,
         hasJsTarget: Boolean,
         output: FileAppender,
-        logger: Logger
+        logger: BuildKonfigLogger
     ) {
         val outputDirectory = getOutputDirectory(configFile, packageName)
 
@@ -32,7 +32,7 @@ object BuildKonfigCompiler {
         exposeObject: Boolean,
         configFile: TargetConfigFile,
         output: FileAppender,
-        logger: Logger
+        logger: BuildKonfigLogger
     ) {
         val outputDirectory = getOutputDirectory(configFile, packageName)
 
@@ -48,7 +48,7 @@ object BuildKonfigCompiler {
         exposeObject: Boolean,
         configFile: TargetConfigFile,
         output: FileAppender,
-        logger: Logger
+        logger: BuildKonfigLogger
     ) {
         val outputDirectory = getOutputDirectory(configFile, packageName)
 

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigGenerator.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigGenerator.kt
@@ -1,7 +1,7 @@
 package com.codingfeline.buildkonfig.compiler.generator
 
 import com.codingfeline.buildkonfig.compiler.FieldSpec
-import com.codingfeline.buildkonfig.compiler.Logger
+import com.codingfeline.buildkonfig.compiler.BuildKonfigLogger
 import com.codingfeline.buildkonfig.compiler.PlatformType
 import com.codingfeline.buildkonfig.compiler.TargetConfigFile
 import com.squareup.kotlinpoet.AnnotationSpec
@@ -16,7 +16,7 @@ abstract class BuildKonfigGenerator(
     val objectAnnotations: List<AnnotationSpec>,
     val objectModifiers: List<KModifier>,
     val propertyModifiers: List<KModifier>,
-    val logger: Logger
+    val logger: BuildKonfigLogger
 ) {
     fun generateFile(packageName: String, objectName: String): FileSpec {
         val builder = FileSpec.builder(packageName, objectName)
@@ -47,7 +47,7 @@ abstract class BuildKonfigGenerator(
             file: TargetConfigFile,
             exposeObject: Boolean,
             hasJsTarget: Boolean,
-            logger: Logger
+            logger: BuildKonfigLogger
         ): BuildKonfigGenerator {
             val objectModifiers = listOf(getVisibilityModifier(exposeObject))
             val annotations = if (exposeObject && hasJsTarget) getJsObjectAnnotations() else emptyList()
@@ -73,7 +73,7 @@ abstract class BuildKonfigGenerator(
         /**
          * Generate common `expect` object
          */
-        fun ofCommon(file: TargetConfigFile, exposeObject: Boolean, logger: Logger): BuildKonfigGenerator {
+        fun ofCommon(file: TargetConfigFile, exposeObject: Boolean, logger: BuildKonfigLogger): BuildKonfigGenerator {
             val objectModifiers = listOf(KModifier.EXPECT, getVisibilityModifier(exposeObject))
             return object : BuildKonfigGenerator(
                 file = file,
@@ -99,7 +99,7 @@ abstract class BuildKonfigGenerator(
         /**
          * Generate target `actual` object
          */
-        fun ofTarget(file: TargetConfigFile, exposeObject: Boolean, logger: Logger): BuildKonfigGenerator {
+        fun ofTarget(file: TargetConfigFile, exposeObject: Boolean, logger: BuildKonfigLogger): BuildKonfigGenerator {
             val objectModifiers = listOf(KModifier.ACTUAL, getVisibilityModifier(exposeObject))
             val annotations = if (exposeObject && file.targetName.platformType == PlatformType.js) {
                 getJsObjectAnnotations()

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -1,6 +1,9 @@
 package com.codingfeline.buildkonfig.gradle
 
+import com.codingfeline.buildkonfig.compiler.BuildKonfigLogger
+import com.codingfeline.buildkonfig.compiler.LogLevel
 import com.codingfeline.buildkonfig.compiler.PlatformType
+import org.gradle.api.logging.Logger
 import com.codingfeline.buildkonfig.compiler.TargetConfig
 import com.codingfeline.buildkonfig.compiler.TargetName
 import com.codingfeline.buildkonfig.gradle.kotlin.sources
@@ -51,8 +54,10 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         project.afterEvaluate { p ->
             val flavor = p.findFlavor()
 
-            val targetConfigs = extension.mergeConfigs(project.logger::info, flavor)
-                .toMutableMap()
+            val mergedConfigs = extension.mergeConfigs(project.logger.toBuildKonfigLogger(), flavor)
+                ?: return@afterEvaluate
+
+            val targetConfigs = mergedConfigs.toMutableMap()
 
             val targetConfigSources = decideOutputs(project, mppExtension, targetConfigs, outputDirectory)
 
@@ -165,6 +170,15 @@ internal fun Project.findFlavor(): String {
     } else {
         logger.error("$FLAVOR_PROPERTY must be string. Fallback to non-flavored config: ${flavor::class.java}")
         DEFAULT_FLAVOR
+    }
+}
+
+internal fun Logger.toBuildKonfigLogger(): BuildKonfigLogger {
+    return BuildKonfigLogger { level, message ->
+        when (level) {
+            LogLevel.INFO -> info(message)
+            LogLevel.WARN -> warn(message)
+        }
     }
 }
 

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpec.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpec.kt
@@ -27,7 +27,7 @@ fun BuildKonfigExtension.mergeConfigs(
     flavor: Flavor = DEFAULT_FLAVOR
 ): Map<String, TargetConfig>? {
     if (!defaultConfigs.containsKey(DEFAULT_FLAVOR)) {
-        logger.warn("BuildKonfig: defaultConfigs is not provided. Skipping code generation.")
+        logger.warn("BuildKonfig: non-flavored defaultConfigs is not provided. Skipping code generation.")
         return null
     }
 

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpec.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpec.kt
@@ -1,5 +1,6 @@
 package com.codingfeline.buildkonfig.gradle
 
+import com.codingfeline.buildkonfig.compiler.BuildKonfigLogger
 import com.codingfeline.buildkonfig.compiler.FieldSpec
 import com.codingfeline.buildkonfig.compiler.TargetConfig
 import com.codingfeline.buildkonfig.compiler.TargetConfigFile
@@ -22,11 +23,12 @@ data class TargetConfigFileImpl(
 ) : TargetConfigFile
 
 fun BuildKonfigExtension.mergeConfigs(
-    logger: (String) -> Unit,
+    logger: BuildKonfigLogger,
     flavor: Flavor = DEFAULT_FLAVOR
-): Map<String, TargetConfig> {
+): Map<String, TargetConfig>? {
     if (!defaultConfigs.containsKey(DEFAULT_FLAVOR)) {
-        throw IllegalStateException("non-flavored defaultConfigs must be provided.")
+        logger.warn("BuildKonfig: defaultConfigs is not provided. Skipping code generation.")
+        return null
     }
 
     val defaultConfig = mergeDefaultConfigs(logger, flavor, defaultConfigs)
@@ -81,7 +83,7 @@ fun mergeConfigs(
 }
 
 fun mergeDefaultConfigs(
-    logger: (String) -> Unit,
+    logger: BuildKonfigLogger,
     flavor: Flavor,
     defaultConfigs: Map<Flavor, TargetConfig>
 ): TargetConfig {
@@ -93,12 +95,12 @@ fun mergeDefaultConfigs(
     }
 
     return mergeConfigs(default, flavored) { old, new ->
-        logger("BuildKonfig(Default): field '${old.name}' is being replaced with flavored($flavor): ${old.value} -> ${new.value}")
+        logger.info("BuildKonfig(Default): field '${old.name}' is being replaced with flavored($flavor): ${old.value} -> ${new.value}")
     }
 }
 
 fun mergeTargetConfigs(
-    logger: (String) -> Unit,
+    logger: BuildKonfigLogger,
     flavor: Flavor, /* = kotlin.String */
     targetConfigs: Map<Flavor, List<TargetConfig>>
 ): Map<String, TargetConfig> {
@@ -123,7 +125,7 @@ fun mergeTargetConfigs(
                 val alreadyPresent = acc[name]
                 acc[name] = if (alreadyPresent != null) {
                     mergeConfigs(alreadyPresent, config) { old, new ->
-                        logger("BuildKonfig($name): field is being replaced with flavored($flavor): ${old.value} -> ${new.value}")
+                        logger.info("BuildKonfig($name): field is being replaced with flavored($flavor): ${old.value} -> ${new.value}")
                     }
                 } else {
                     config.copy()

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
@@ -59,7 +59,7 @@ open class BuildKonfigTask : DefaultTask() {
             hasJsTarget = hasJsTarget
         )
 
-        BuildKonfigEnvironment(data).generateConfigs { info -> logger.info(info) }
+        BuildKonfigEnvironment(data).generateConfigs(logger.toBuildKonfigLogger())
     }
 
     private fun File.cleanupDirectory() {

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
@@ -121,7 +121,7 @@ class BuildKonfigPluginTest {
     }
 
     @Test
-    fun `buildkonfig block without defaultConfigs throws`() {
+    fun `buildkonfig block without defaultConfigs warns and skips`() {
         buildFile.writeText(
             """
             |$buildFileHeader
@@ -166,10 +166,12 @@ class BuildKonfigPluginTest {
 
         val result = runner
             .withArguments("build", "--stacktrace")
-            .buildAndFail()
+            .build()
 
         assertThat(result.output)
-            .contains("non-flavored defaultConfigs must be provided")
+            .contains("BuildKonfig: defaultConfigs is not provided. Skipping code generation.")
+        assertThat(result.output)
+            .contains("BUILD SUCCESSFUL")
     }
 
     @Test

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
@@ -169,7 +169,7 @@ class BuildKonfigPluginTest {
             .build()
 
         assertThat(result.output)
-            .contains("BuildKonfig: defaultConfigs is not provided. Skipping code generation.")
+            .contains("BuildKonfig: non-flavored defaultConfigs is not provided. Skipping code generation.")
         assertThat(result.output)
             .contains("BUILD SUCCESSFUL")
     }


### PR DESCRIPTION
Closes #259

## Summary
- Warn instead of throwing `IllegalStateException` when `defaultConfigs` is not provided, allowing Gradle sync to succeed
- Replace `typealias Logger = (String) -> Unit` with `BuildKonfigLogger` fun interface supporting structured log levels (INFO, WARN)
- Define `BuildKonfigLogger` in buildkonfig-compiler module so both compiler and gradle-plugin can use it

## Test plan
- [x] `./gradlew clean build` — all tests pass
- [x] `buildkonfig block without defaultConfigs warns and skips` test verifies warning output and BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)