### PR TITLE
fix: validate buildConfigField name is a valid Kotlin identifier

### DIFF
--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/FieldSpec.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/FieldSpec.kt
@@ -13,6 +13,14 @@ data class FieldSpec(
     val const: Boolean = false,
 ) : Serializable {
 
+    init {
+        require(name.isNotEmpty()) { "buildConfigField name must not be empty" }
+        require(name.matches(VALID_IDENTIFIER_REGEX)) {
+            "buildConfigField name '$name' is not a valid Kotlin identifier. " +
+                "It must start with a letter or underscore, followed by letters, digits, or underscores."
+        }
+    }
+
     enum class Type(val _typeName: TypeName, val _template: String = "%L") {
         STRING(String::class.asTypeName(), "%S"),
         INT(Int::class.asTypeName()),
@@ -32,4 +40,8 @@ data class FieldSpec(
 
     val template: String
         get() = with(type) { if (nullable && value == null) "%L" else _template }
+
+    companion object {
+        private val VALID_IDENTIFIER_REGEX = Regex("^[a-zA-Z_][a-zA-Z0-9_]*$")
+    }
 }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
@@ -204,7 +204,7 @@ class BuildKonfigPluginTest {
             .buildAndFail()
 
         assertThat(result.output)
-            .contains("is not a valid Kotlin identifier")
+            .contains("buildConfigField name 'API.URL' is not a valid Kotlin identifier")
     }
 
     @Test

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
@@ -175,6 +175,39 @@ class BuildKonfigPluginTest {
     }
 
     @Test
+    fun `buildConfigField with invalid name throws`() {
+        buildFile.writeText(
+            """
+            |$buildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.sample"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'API.URL', 'http://localhost'
+            |   }
+            |}
+            |
+            |$buildFileMPPConfig
+            """.trimMargin()
+        )
+
+        val buildDir = File(projectDir.root, "build/buildkonfig")
+        buildDir.deleteRecursively()
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        val result = runner
+            .withArguments("generateBuildKonfig", "--stacktrace")
+            .buildAndFail()
+
+        assertThat(result.output)
+            .contains("is not a valid Kotlin identifier")
+    }
+
+    @Test
     fun `Applying the plugin works fine for multiplatform project`() {
         buildFile.writeText(
             """


### PR DESCRIPTION
Closes #262

## Summary
- Add validation in `FieldSpec` constructor to reject invalid Kotlin identifiers (e.g. `API.URL`)
- Previously, invalid names silently produced an empty BuildKonfig object with no error
- Now throws `IllegalArgumentException` with a clear message indicating what's wrong

## Test plan
- [x] `./gradlew clean build` — all tests pass
- [x] New test `buildConfigField with invalid name throws` verifies the error message