### PR TITLE
fix: expose compiler module as api dependency

### DIFF
--- a/buildkonfig-gradle-plugin/build.gradle.kts
+++ b/buildkonfig-gradle-plugin/build.gradle.kts
@@ -40,7 +40,7 @@ tasks.pluginUnderTestMetadata {
 }
 
 dependencies {
-    implementation(projects.buildkonfigCompiler)
+    api(projects.buildkonfigCompiler)
 //    implementation(kotlin("stdlib-jdk8", Versions.kotlin))
 
     compileOnly(gradleApi())


### PR DESCRIPTION
## Summary

- Change `buildkonfig-compiler` from `implementation` to `api` dependency in the Gradle plugin module (#227)
- `FieldSpec.Type` is part of the plugin's public DSL API (used in `buildConfigField()` parameters), so it should be transitively available to consumers
- This fixes the issue where Gradle convention plugins could not resolve `com.codingfeline.buildkonfig.compiler.FieldSpec.Type` without manually adding a dependency on `buildkonfig-compiler`

## Test plan

- [x] Build and all existing tests pass
- [x] Verified `api` configuration is available via `java-gradle-plugin`

Closes #227