### PR TITLE
fix: preserve flavor in TargetConfig.copy()

### DIFF
--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/TargetConfig.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/TargetConfig.kt
@@ -8,5 +8,8 @@ open class TargetConfig(val name: String) : Serializable {
 
     fun copyFieldSpecs(): Map<String, FieldSpec> = fieldSpecs.mapValues { it.value.copy() }
 
-    fun copy(): TargetConfig = TargetConfig(name).also { it.fieldSpecs.putAll(copyFieldSpecs()) }
+    fun copy(): TargetConfig = TargetConfig(name).also {
+        it.flavor = flavor
+        it.fieldSpecs.putAll(copyFieldSpecs())
+    }
 }


### PR DESCRIPTION
## Summary

- `TargetConfig.copy()` was not copying the `flavor` property, causing it to reset to an empty string during config merging
- This could contribute to stale flavor values when configs are copied as fallbacks in `decideOutputs()` (#210)

## Changes

One-line fix in `TargetConfig.copy()` to preserve the `flavor` field.

## Note

This fixes a clear bug in `TargetConfig.copy()`, but may not fully resolve #210. The reporter's symptom ("generated source is correct but breakpoint shows old value") could also involve Kotlin incremental compilation not detecting changes in generated source files, or IDE caching issues.

## Test plan

- [x] All existing tests pass