### PR TITLE
refactor: replace nested afterEvaluate with plugins.withType()

### DIFF
--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -23,11 +23,21 @@ const val COMMON_SOURCESET_NAME = "commonMain"
 @Suppress("unused")
 abstract class BuildKonfigPlugin : Plugin<Project> {
 
+    private var isMultiplatform = false
+
     override fun apply(target: Project) {
         val extension = target.extensions.create("buildkonfig", BuildKonfigExtension::class.java, target)
 
         target.plugins.withType(KotlinMultiplatformPluginWrapper::class.java) {
+            isMultiplatform = true
             configure(target, extension)
+        }
+
+        target.afterEvaluate {
+            check(isMultiplatform) {
+                "BuildKonfig Gradle plugin applied in project '${target.path}' " +
+                    "but no supported Kotlin multiplatform plugin was found"
+            }
         }
     }
 

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -24,24 +24,9 @@ const val COMMON_SOURCESET_NAME = "commonMain"
 abstract class BuildKonfigPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
-
-        var isMultiplatform = false
-        target.plugins.all { p ->
-            if (p is KotlinMultiplatformPluginWrapper) {
-                isMultiplatform = true
-            }
-        }
-
         val extension = target.extensions.create("buildkonfig", BuildKonfigExtension::class.java, target)
 
-        target.afterEvaluate {
-            if (!isMultiplatform) {
-                throw IllegalStateException(
-                    "BuildKonfig Gradle plugin applied in project '${target.path}' " +
-                            "but no supported Kotlin multiplatform plugin was found"
-                )
-            }
-
+        target.plugins.withType(KotlinMultiplatformPluginWrapper::class.java) {
             configure(target, extension)
         }
     }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
@@ -106,7 +106,7 @@ class BuildKonfigPluginTest {
             .contains("BUILD SUCCESSFUL")
 
         // No buildkonfig output should be generated
-        assertThat(buildDir.exists()).isFalse()
+        assertThat(buildDir.list()).isNull()
     }
 
     @Test

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
@@ -67,7 +67,7 @@ class BuildKonfigPluginTest {
     }
 
     @Test
-    fun `Applying plugin without KMP plugin is a no-op`() {
+    fun `Applying plugin without KMP plugin throws`() {
         buildFile.writeText(
             """
             |plugins {
@@ -100,13 +100,10 @@ class BuildKonfigPluginTest {
 
         val result = runner
             .withArguments("build", "--stacktrace")
-            .build()
+            .buildAndFail()
 
         assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        // No buildkonfig output should be generated
-        assertThat(buildDir.list()).isNull()
+            .contains("BuildKonfig Gradle plugin applied in project ':' but no supported Kotlin multiplatform plugin was found")
     }
 
     @Test

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
@@ -67,7 +67,7 @@ class BuildKonfigPluginTest {
     }
 
     @Test
-    fun `Applying plugin with kotlin jvm plugin throws`() {
+    fun `Applying plugin without KMP plugin is a no-op`() {
         buildFile.writeText(
             """
             |plugins {
@@ -84,20 +84,6 @@ class BuildKonfigPluginTest {
             |
             |   defaultConfigs {
             |       buildConfigField 'STRING', 'test', 'hoge'
-            |       buildConfigField 'INT', 'intValue', '10'
-            |   }
-            |
-            |   targetConfigs {
-            |       jvm {
-            |           buildConfigField 'STRING', 'test', 'jvm'
-            |           buildConfigField 'STRING', 'jmv', 'jvmHoge'
-            |       }
-            |       customAndroid {
-            |           buildConfigField 'String', 'android', '${'$'}fuga'
-            |       }
-            |       iosX64 {
-            |           buildConfigField 'String', 'native', 'fuge'
-            |       }
             |   }
             |}
             |
@@ -114,10 +100,13 @@ class BuildKonfigPluginTest {
 
         val result = runner
             .withArguments("build", "--stacktrace")
-            .buildAndFail()
+            .build()
 
         assertThat(result.output)
-            .contains("BuildKonfig Gradle plugin applied in project ':' but no supported Kotlin multiplatform plugin was found")
+            .contains("BUILD SUCCESSFUL")
+
+        // No buildkonfig output should be generated
+        assertThat(buildDir.exists()).isFalse()
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Replace the nested `afterEvaluate` anti-pattern with `plugins.withType()` + validation `afterEvaluate` (part of #279)
- Was: `apply → afterEvaluate { validate + configure → afterEvaluate { ... } }` (nested)
- Now: `apply → plugins.withType { configure → afterEvaluate { ... } }` + `afterEvaluate { validate }` (flat)

## Approach

Following the same pattern used by other Gradle plugins:

1. `plugins.withType(KotlinMultiplatformPluginWrapper)` — detect KMP plugin and trigger `configure()` when applied
2. Separate `afterEvaluate` — validate that KMP was actually applied, throwing an error if not

This eliminates the nested `afterEvaluate` which had unpredictable execution timing with Configuration Cache.

Note: #279 also mentions adopting Provider-based lazy configuration and avoiding `Provider.get()` during configuration. That is a separate, larger refactor and is not included in this PR.

## Test plan

- [x] `Applying plugin without KMP plugin throws` — error message preserved
- [x] All existing tests pass
- [x] Both sample and sample-kts generate correctly