### PR TITLE
chore: migrate eligible workflows to ubuntu-slim runner

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   validate_pr_title:
     name: Validate PR title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release_please:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary
Ubuntu Slim Runner は軽量・低コストなランナーで、以下のような軽量ワークフロー向きです:
- release-please / PR タイトル検証 / claude-code / tag 自動化 / 軽量 Node CI 等

制約 (15分タイムアウト / unprivileged container / 最小プリインツール) に合致するワークフローのみ対象としています。Gradle/Rust/Go/Dart/fastlane 等の重量ビルドは対象外です。

### 変更対象
- `.github/workflows/pr-title-validation.yml`
- `.github/workflows/release-please.yml`

### 調査の詳細
関連調査タスク: yshrsmz 配下リポジトリの Slim Runner 化可能性調査 (2026-04-15 完了)

## Test plan
- [ ] PR 作成後、対象ワークフローが push/label/issue 等のトリガーで正常に動作することを確認