### PR TITLE
fix: drop const modifier from expect side for K2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,14 @@ buildkonfig {
 - `buildConfigField(type: String, name: String, value: String, nullable: Boolean = false, const: Boolean = false)` 
   - In addition to above method, this can configure `nullable` and `const` declarations.
 
+> [!NOTE]
+> When `targetConfigs` are present, BuildKonfig is generated as `expect`/`actual`. The K2 compiler (Kotlin 2.x)
+> does not allow `expect const val`, so the common-side declaration is emitted as plain `val` even if you set
+> `const = true`. Each target's `actual` declaration still uses `actual const val`, so the value is a
+> compile-time constant inside target-specific source sets — but **common code cannot reference it as a
+> compile-time constant** (e.g. inside `when` branches that require constants, or annotation arguments).
+> A warning is logged at generation time for affected fields.
+
 Above configuration will generate following codes.
 
 ```kotlin

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironment.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironment.kt
@@ -107,11 +107,11 @@ class BuildKonfigEnvironment(
         }
 
         logger.warn(
-            "BuildKonfig: const = true is not honored on the common (expect) side when target-specific " +
-                "configs are present (K2 compiler restricts `expect const val`). The expect declaration " +
-                "is emitted as `val`, while each target keeps `actual const val`. Affected field(s): " +
-                "${constFieldNames.joinToString(", ")}. Common code cannot reference these as compile-time " +
-                "constants; use them as constants only from target-specific source sets."
+            "BuildKonfig: field(s) [${constFieldNames.joinToString(", ")}] are declared with " +
+                "`const = true` but target-specific configs are present. The K2 compiler does not " +
+                "allow `expect const val`, so the common declaration is emitted as `val` (each " +
+                "target still uses `actual const val`). Common code cannot reference these as " +
+                "compile-time constants."
         )
     }
 }

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironment.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironment.kt
@@ -58,6 +58,9 @@ class BuildKonfigEnvironment(
 
     private fun compileExpectActual(data: BuildKonfigData, writer: FileAppender, logger: BuildKonfigLogger): List<String> {
         val errors = mutableListOf<String>()
+
+        warnConstFieldsInExpectActual(data, logger)
+
         try {
             BuildKonfigCompiler.compileCommon(
                 data.packageName,
@@ -87,5 +90,21 @@ class BuildKonfigEnvironment(
                 }
             }
         return errors
+    }
+
+    private fun warnConstFieldsInExpectActual(data: BuildKonfigData, logger: BuildKonfigLogger) {
+        val constFieldNames = data.commonConfig.config?.fieldSpecs?.values
+            ?.filter { it.const }
+            ?.map { it.name }
+            ?.takeIf { it.isNotEmpty() }
+            ?: return
+
+        logger.warn(
+            "BuildKonfig: const = true is not honored on the common (expect) side when target-specific " +
+                "configs are present (K2 compiler restricts `expect const val`). The expect declaration " +
+                "is emitted as `val`, while each target keeps `actual const val`. Affected field(s): " +
+                "${constFieldNames.joinToString(", ")}. Common code cannot reference these as compile-time " +
+                "constants; use them as constants only from target-specific source sets."
+        )
     }
 }

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironment.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironment.kt
@@ -93,11 +93,18 @@ class BuildKonfigEnvironment(
     }
 
     private fun warnConstFieldsInExpectActual(data: BuildKonfigData, logger: BuildKonfigLogger) {
-        val constFieldNames = data.commonConfig.config?.fieldSpecs?.values
-            ?.filter { it.const }
-            ?.map { it.name }
-            ?.takeIf { it.isNotEmpty() }
-            ?: return
+        val commonConfig = data.commonConfig.config
+        if (commonConfig == null) {
+            return
+        }
+
+        val constFieldNames = commonConfig.fieldSpecs.values
+            .filter { it.const }
+            .map { it.name }
+
+        if (constFieldNames.isEmpty()) {
+            return
+        }
 
         logger.warn(
             "BuildKonfig: const = true is not honored on the common (expect) side when target-specific " +

--- a/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigGenerator.kt
+++ b/buildkonfig-compiler/src/main/kotlin/com/codingfeline/buildkonfig/compiler/generator/BuildKonfigGenerator.kt
@@ -71,7 +71,12 @@ abstract class BuildKonfigGenerator(
         }
 
         /**
-         * Generate common `expect` object
+         * Generate common `expect` object.
+         *
+         * `const` is intentionally omitted on the expect side: starting with the K2 compiler
+         * (Kotlin 2.x), `expect const val` without an initializer is a hard compile error and
+         * the previous `@Suppress("CONST_VAL_WITHOUT_INITIALIZER")` workaround no longer
+         * applies. `expect val` paired with `actual const val` is a supported pattern.
          */
         fun ofCommon(file: TargetConfigFile, exposeObject: Boolean, logger: BuildKonfigLogger): BuildKonfigGenerator {
             val objectModifiers = listOf(KModifier.EXPECT, getVisibilityModifier(exposeObject))
@@ -83,15 +88,9 @@ abstract class BuildKonfigGenerator(
                 logger = logger
             ) {
                 override fun generateProp(fieldSpec: FieldSpec): PropertySpec {
-                    val spec = PropertySpec.builder(fieldSpec.name, fieldSpec.typeName)
+                    return PropertySpec.builder(fieldSpec.name, fieldSpec.typeName)
                         .addModifiers(*propertyModifiers.toTypedArray())
-                    if (fieldSpec.const) {
-                        spec.addModifiers(KModifier.CONST)
-                            .addAnnotation(AnnotationSpec.builder(ClassName("kotlin", "Suppress"))
-                            .addMember("%S", "CONST_VAL_WITHOUT_INITIALIZER")
-                            .build())
-                    }
-                    return spec.build()
+                        .build()
                 }
             }
         }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
@@ -80,11 +80,16 @@ class BuildKonfigPluginConstFieldsTest {
             .withPluginClasspath()
 
         val result = runner
-            .withArguments("generateBuildKonfig", "--stacktrace")
+            .withArguments("generateBuildKonfig", "--stacktrace", "--warning-mode=all")
             .build()
 
         Truth.assertThat(result.output)
             .contains("BUILD SUCCESSFUL")
+
+        Truth.assertThat(result.output).apply {
+            contains("const = true is not honored on the common (expect) side")
+            contains("foo, bar")
+        }
 
         val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
         Truth.assertThat(commonResult.readText()).apply {

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
@@ -87,8 +87,9 @@ class BuildKonfigPluginConstFieldsTest {
             .contains("BUILD SUCCESSFUL")
 
         Truth.assertThat(result.output).apply {
-            contains("const = true is not honored on the common (expect) side")
-            contains("foo, bar")
+            contains("declared with `const = true` but target-specific configs are present")
+            contains("foo")
+            contains("bar")
         }
 
         val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
@@ -47,7 +47,7 @@ class BuildKonfigPluginConstFieldsTest {
     }
 
     @Test
-    fun `const values for expect object contains suppress annotation`() {
+    fun `const values produce expect val on common and actual const val on targets`() {
         buildFile.writeText(
             """
             |import com.codingfeline.buildkonfig.compiler.FieldSpec.Type
@@ -88,31 +88,23 @@ class BuildKonfigPluginConstFieldsTest {
 
         val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
         Truth.assertThat(commonResult.readText()).apply {
-            contains(
-                """
-                |  @Suppress("CONST_VAL_WITHOUT_INITIALIZER")
-                |  public const val foo
-            """.trimMargin()
-            )
-
-            contains(
-                """
-                |  @Suppress("CONST_VAL_WITHOUT_INITIALIZER")
-                |  public const val bar
-            """.trimMargin()
-            )
+            contains("public val foo: String")
+            contains("public val bar: String")
+            doesNotContain("const val foo")
+            doesNotContain("const val bar")
+            doesNotContain("CONST_VAL_WITHOUT_INITIALIZER")
         }
 
         val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
         Truth.assertThat(jvmResult.readText()).apply {
-            contains("const val foo: String = \"defaultValue\"")
-            contains("const val bar: String = \"defaultBarValue\"")
+            contains("actual const val foo: String = \"defaultValue\"")
+            contains("actual const val bar: String = \"defaultBarValue\"")
         }
 
         val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
         Truth.assertThat(jsResult.readText()).apply {
-            contains("const val foo: String = \"jsValue\"")
-            contains("const val bar: String = \"jsBarValue\"")
+            contains("actual const val foo: String = \"jsValue\"")
+            contains("actual const val bar: String = \"jsBarValue\"")
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #277 — `expect const val` without an initializer is a hard compile error under the K2 compiler (Kotlin 2.x), and the previous `@Suppress("CONST_VAL_WITHOUT_INITIALIZER")` workaround no longer applies.
- `BuildKonfigGenerator.ofCommon()` now emits `expect val` on the common side; `ofTarget()` continues to emit `actual const val` on each target. `expect val` + `actual const val` is a supported Kotlin pattern (see [KT-18856](https://youtrack.jetbrains.com/issue/KT-18856)).
- Updated `BuildKonfigPluginConstFieldsTest` to assert the new shape: common side has `public val`, no `const` and no `@Suppress`; target sides have `actual const val`.

## Test plan

- [x] `./gradlew :buildkonfig-gradle-plugin:test --tests "com.codingfeline.buildkonfig.gradle.BuildKonfigPluginConstFieldsTest"` passes
- [x] `./gradlew test` passes (full suite, no regressions)
- [ ] Optional: publish locally and verify with `sample` / `sample-kts` against Kotlin 2.3+

🤖 Generated with [Claude Code](https://claude.com/claude-code)