### PR TITLE
refactor!: lazy/Provider configuration to fix Gradle 9 compat and CC

### DIFF
--- a/buildkonfig-gradle-plugin/build.gradle.kts
+++ b/buildkonfig-gradle-plugin/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
 
     fixtureClasspath(libs.kotlin.plugin)
     fixtureClasspath(libs.android.plugin)
+    fixtureClasspath(libs.ksp.plugin)
 }
 
 tasks.compileKotlin {

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -46,6 +46,18 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
 
         val mppExtension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
 
+        // Register the task eagerly (outside afterEvaluate) so its outputs participate in
+        // Gradle's task graph as Providers from the start. This is what allows downstream
+        // tasks (e.g. KSP under Gradle 9.0) to discover an implicit dependency edge through
+        // the source set's srcDirs Provider chain.
+        val task = project.tasks.register("generateBuildKonfig", BuildKonfigTask::class.java) {
+            it.group = "buildkonfig"
+            it.description = "generate BuildKonfig"
+        }
+
+        // A single, flat afterEvaluate is used purely to compute the merged configuration
+        // (which depends on extension DSL evaluation and KMP target registration completing)
+        // and to wire generated source directories into Kotlin source sets.
         project.afterEvaluate { p ->
             val flavor = p.findFlavor()
 
@@ -65,19 +77,16 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
             val hasWasmTarget = mppExtension.targets.any { t -> t.platformType == KotlinPlatformType.wasm }
             val forceExpectActual = exposeObject && hasJsTarget && hasWasmTarget
 
-            val targetConfigSources = decideOutputs(project, mppExtension, targetConfigs, outputDirectory, forceExpectActual)
+            val targetConfigSources =
+                decideOutputs(project, mppExtension, targetConfigs, outputDirectory, forceExpectActual)
 
-            val task = p.tasks.register("generateBuildKonfig", BuildKonfigTask::class.java) {
-                it.packageName = requireNotNull(extension.packageName) { "packageName must be provided" }
-
-                it.objectName = objectName
-                it.exposeObject = exposeObject
-                it.hasJsTarget = hasJsTarget
-                it.flavor = flavor
-                it.targetConfigFiles = targetConfigSources.mapValues { (_, value) -> value.configFile }
-
-                it.group = "buildkonfig"
-                it.description = "generate BuildKonfig"
+            task.configure { t ->
+                t.packageName.set(requireNotNull(extension.packageName) { "packageName must be provided" })
+                t.objectName.set(objectName)
+                t.exposeObject.set(exposeObject)
+                t.hasJsTarget.set(hasJsTarget)
+                t.flavor.set(flavor)
+                t.targetConfigFiles.set(targetConfigSources.mapValues { (_, value) -> value.configFile })
             }
 
             targetConfigSources.forEach { (key, configSource) ->
@@ -190,5 +199,3 @@ internal fun KotlinPlatformType.toPlatformType(): PlatformType {
         KotlinPlatformType.wasm -> PlatformType.wasm
     }
 }
-
-

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
@@ -4,6 +4,8 @@ import com.codingfeline.buildkonfig.VERSION
 import com.codingfeline.buildkonfig.compiler.BuildKonfigData
 import com.codingfeline.buildkonfig.compiler.BuildKonfigEnvironment
 import org.gradle.api.DefaultTask
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectories
@@ -12,7 +14,7 @@ import java.io.File
 
 const val FLAVOR_PROPERTY = "buildkonfig.flavor"
 
-open class BuildKonfigTask : DefaultTask() {
+abstract class BuildKonfigTask : DefaultTask() {
 
     // Required to invalidate the task on version updates.
     @Suppress("unused")
@@ -21,42 +23,44 @@ open class BuildKonfigTask : DefaultTask() {
         get() = VERSION
 
     @get:Input
-    lateinit var packageName: String
+    abstract val packageName: Property<String>
 
     @get:Input
-    lateinit var objectName: String
-
-    @Input
-    var exposeObject: Boolean = false
-
-    @Input
-    var hasJsTarget: Boolean = false
+    abstract val objectName: Property<String>
 
     @get:Input
-    lateinit var flavor: String
+    abstract val exposeObject: Property<Boolean>
+
+    @get:Input
+    abstract val hasJsTarget: Property<Boolean>
+
+    @get:Input
+    abstract val flavor: Property<String>
 
     @get:Nested
-    lateinit var targetConfigFiles: Map<String, TargetConfigFileImpl>
+    abstract val targetConfigFiles: MapProperty<String, TargetConfigFileImpl>
 
     @Suppress("unused")
     @get:OutputDirectories
     val outputDirectories: Map<String, File>
-        get() = targetConfigFiles.mapValues { it.value.outputDirectory }
+        get() = targetConfigFiles.get().mapValues { it.value.outputDirectory }
 
     @Suppress("unused")
     @TaskAction
     fun generateBuildKonfigFiles() {
+        val outputDirs = outputDirectories
         // clean up output directories
-        outputDirectories.getValue(COMMON_SOURCESET_NAME).parentFile.cleanupDirectory()
-        outputDirectories.forEach { it.value.mkdirs() }
+        outputDirs.getValue(COMMON_SOURCESET_NAME).parentFile.cleanupDirectory()
+        outputDirs.forEach { it.value.mkdirs() }
 
+        val configFiles = targetConfigFiles.get()
         val data = BuildKonfigData(
-            packageName = packageName,
-            objectName = objectName,
-            exposeObject = exposeObject,
-            commonConfig = targetConfigFiles.getValue(COMMON_SOURCESET_NAME),
-            targetConfigs = targetConfigFiles.filter { it.key != COMMON_SOURCESET_NAME }.values.toList(),
-            hasJsTarget = hasJsTarget
+            packageName = packageName.get(),
+            objectName = objectName.get(),
+            exposeObject = exposeObject.get(),
+            commonConfig = configFiles.getValue(COMMON_SOURCESET_NAME),
+            targetConfigs = configFiles.filter { it.key != COMMON_SOURCESET_NAME }.values.toList(),
+            hasJsTarget = hasJsTarget.get()
         )
 
         BuildKonfigEnvironment(data).generateConfigs(logger.toBuildKonfigLogger())

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConfigurationCacheTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConfigurationCacheTest.kt
@@ -1,0 +1,108 @@
+package com.codingfeline.buildkonfig.gradle
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class BuildKonfigPluginConfigurationCacheTest {
+
+    @get:Rule
+    val projectDir = TemporaryFolder()
+
+    lateinit var buildFile: File
+
+    lateinit var settingFile: File
+
+    private val buildFileHeader = """
+        |plugins {
+        |    id 'kotlin-multiplatform'
+        |    id 'com.codingfeline.buildkonfig'
+        |}
+        |
+        |repositories {
+        |   mavenCentral()
+        |}
+        |
+    """.trimMargin()
+
+    private val buildFileMPPConfig = """
+        |kotlin {
+        |  jvm()
+        |  iosX64()
+        |
+        |  sourceSets {
+        |    commonMain {
+        |      dependencies {}
+        |    }
+        |    jvmMain {
+        |      dependencies {}
+        |    }
+        |  }
+        |}
+    """.trimMargin()
+
+    @Before
+    fun setup() {
+        buildFile = projectDir.newFile("build.gradle")
+        settingFile = projectDir.newFile("settings.gradle")
+        settingFile.writeText(settingsGradle)
+    }
+
+    @Test
+    fun `generateBuildKonfig is compatible with Configuration Cache`() {
+        buildFile.writeText(
+            """
+            |$buildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.sample"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'test', 'hoge'
+            |       buildConfigField 'INT', 'intValue', '10'
+            |   }
+            |
+            |   targetConfigs {
+            |       jvm {
+            |           buildConfigField 'STRING', 'test', 'jvm'
+            |       }
+            |   }
+            |}
+            |
+            |$buildFileMPPConfig
+            """.trimMargin()
+        )
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        // First run: store the configuration cache entry.
+        val firstRun = runner
+            .withArguments(
+                "generateBuildKonfig",
+                "--configuration-cache",
+                "--configuration-cache-problems=fail",
+                "--stacktrace"
+            )
+            .build()
+
+        assertThat(firstRun.output).contains("Configuration cache entry stored")
+
+        // Second run: reuse the configuration cache entry.
+        val secondRun = runner
+            .withArguments(
+                "generateBuildKonfig",
+                "--configuration-cache",
+                "--configuration-cache-problems=fail",
+                "--stacktrace"
+            )
+            .build()
+
+        assertThat(secondRun.output).contains("Configuration cache entry reused")
+    }
+}

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
@@ -900,4 +900,57 @@ class BuildKonfigPluginFlavorTest {
             contains("object AwesomeConfig")
         }
     }
+
+    @Test
+    fun `changing flavor between builds re-runs the task with the new flavor value`() {
+        buildFile.writeText(
+            """
+            |$buildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.example"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'stringValue', 'defaultValue'
+            |   }
+            |   defaultConfigs("dev") {
+            |       buildConfigField 'STRING', 'stringValue', 'devDefaultValue'
+            |   }
+            |   defaultConfigs("release") {
+            |       buildConfigField 'STRING', 'stringValue', 'releaseDefaultValue'
+            |   }
+            |}
+            |$buildFileMPPConfig
+        """.trimMargin()
+        )
+
+        val buildDir = File(projectDir.root, "build/buildkonfig")
+        buildDir.deleteRecursively()
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        // First build with flavor=dev
+        val devResult = runner
+            .withArguments("generateBuildKonfig", "--stacktrace", "-Pbuildkonfig.flavor=dev")
+            .build()
+
+        Truth.assertThat(devResult.output).contains("BUILD SUCCESSFUL")
+        val devCommon = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        Truth.assertThat(devCommon.readText())
+            .contains("val stringValue: String = \"devDefaultValue\"")
+
+        // Second build with flavor=release should NOT be UP-TO-DATE and must regenerate.
+        val releaseResult = runner
+            .withArguments("generateBuildKonfig", "--stacktrace", "-Pbuildkonfig.flavor=release")
+            .build()
+
+        Truth.assertThat(releaseResult.output).contains("BUILD SUCCESSFUL")
+        Truth.assertThat(releaseResult.output).doesNotContain("generateBuildKonfig UP-TO-DATE")
+
+        val releaseCommon = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        Truth.assertThat(releaseCommon.readText())
+            .contains("val stringValue: String = \"releaseDefaultValue\"")
+    }
 }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginGradle9KspTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginGradle9KspTest.kt
@@ -1,0 +1,103 @@
+package com.codingfeline.buildkonfig.gradle
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Regression test for issue #236: Gradle 9.0 + KSP combinations failed with an "implicit
+ * dependency" error because KSP tasks consume the `generateBuildKonfig` output directory
+ * via `kotlin.srcDirs(...)` without a declared task dependency. After the lazy/Provider
+ * refactor the source set Provider chain establishes the dependency automatically.
+ */
+class BuildKonfigPluginGradle9KspTest {
+
+    @get:Rule
+    val projectDir = TemporaryFolder()
+
+    lateinit var buildFile: File
+
+    lateinit var settingFile: File
+
+    private val buildFileHeader = """
+        |plugins {
+        |    id 'kotlin-multiplatform'
+        |    id 'com.google.devtools.ksp'
+        |    id 'com.codingfeline.buildkonfig'
+        |}
+        |
+        |repositories {
+        |   mavenCentral()
+        |}
+        |
+    """.trimMargin()
+
+    @Before
+    fun setup() {
+        buildFile = projectDir.newFile("build.gradle")
+        settingFile = projectDir.newFile("settings.gradle")
+        settingFile.writeText(settingsGradle)
+    }
+
+    @Test
+    fun `KSP task does not fail with implicit dependency error on Gradle 9 x`() {
+        buildFile.writeText(
+            """
+            |$buildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.sample"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'test', 'hoge'
+            |   }
+            |}
+            |
+            |kotlin {
+            |  jvm()
+            |
+            |  sourceSets {
+            |    commonMain {
+            |      dependencies {}
+            |    }
+            |    jvmMain {
+            |      dependencies {}
+            |    }
+            |  }
+            |}
+            """.trimMargin()
+        )
+
+        // Provide a dummy Kotlin source so that compileKotlinJvm has something to compile,
+        // exercising the source set wiring (and therefore the Provider-based task dependency
+        // edge from the source set into generateBuildKonfig).
+        projectDir.newFolder("src", "jvmMain", "kotlin")
+        projectDir.newFile("src/jvmMain/kotlin/Sample.kt").writeText(
+            """
+            |package com.sample
+            |
+            |object Sample
+            """.trimMargin()
+        )
+
+        val runner = GradleRunner.create()
+            .withGradleVersion("9.3.1")
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        val result = runner
+            .withArguments("compileKotlinJvm", "--stacktrace")
+            .build()
+
+        assertThat(result.output).contains("BUILD SUCCESSFUL")
+        // Implicit-dependency error message from Gradle 9.x must not surface.
+        assertThat(result.output)
+            .doesNotContain("without declaring an explicit or implicit dependency")
+        // generateBuildKonfig must have actually run.
+        assertThat(result.output).contains("generateBuildKonfig")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ gradle = "8.13"
 kotlin = "2.3.21"
 dokka = "2.2.0"
 android = "8.13.2"
+ksp = "2.3.6"
 
 [libraries]
 kotlinpoet = { module = "com.squareup:kotlinpoet", version = "2.3.0" }
@@ -11,6 +12,7 @@ truth = { module = "com.google.truth:truth", version = "1.4.5" }
 
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 android-plugin = { module = "com.android.tools.build:gradle", version.ref = "android" }
+ksp-plugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

- Migrate `BuildKonfigTask` inputs to `Property<T>` / `MapProperty<...>` and register the task **outside** `afterEvaluate` so the source set's `srcDirs` Provider chain establishes an implicit task dependency on `generateBuildKonfig`. This fixes the `"implicit dependency"` error from Gradle 9.x + KSP and makes the plugin Configuration Cache compatible.
- The remaining `afterEvaluate` is now a single, flat block that computes the merged config once and wires generated source directories into the Kotlin source sets (no nested `afterEvaluate`, no eager `Provider.get()` calls outside the appropriate phase).

Closes #236
Closes #279

## Breaking change

`BuildKonfigTask` inputs are now `Property<T>` / `MapProperty<...>` instead of `lateinit var`. Direct task configurators (e.g. `tasks.named("generateBuildKonfig") { ... }`) must use `.set(...)` instead of `=` in the Kotlin DSL.

```kotlin
// Before
tasks.named<BuildKonfigTask>("generateBuildKonfig") {
    packageName = "com.example"
}

// After
tasks.named<BuildKonfigTask>("generateBuildKonfig") {
    packageName.set("com.example")
}
```

## New regression tests

- `BuildKonfigPluginConfigurationCacheTest` — runs `generateBuildKonfig` twice with `--configuration-cache --configuration-cache-problems=fail` and asserts the cache entry is stored and then reused.
- `BuildKonfigPluginFlavorTest.changing flavor between builds re-runs the task with the new flavor value` — verifies `-Pbuildkonfig.flavor=dev` → `release` triggers task re-execution and updates output (regression for #210).
- `BuildKonfigPluginGradle9KspTest` — exercises Gradle 9.3.1 + KSP end-to-end and asserts the implicit-dependency error from Gradle 9.x does not surface.

## Test plan

- [x] `./gradlew clean build` — 32 tests, all pass
- [x] `./gradlew -p sample generateBuildKonfig` — succeeds, `Configuration cache entry stored.`
- [x] `./gradlew -p sample-kts generateBuildKonfig` — succeeds, `Configuration cache entry stored.`
- [x] New CC test passes
- [x] New flavor invalidation test passes
- [x] New Gradle 9.3.1 + KSP test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)