### PR TITLE
refactor!: migrate BuildKonfigExtension to the Provider API

### DIFF
--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigDsl.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigDsl.kt
@@ -1,0 +1,4 @@
+package com.codingfeline.buildkonfig.gradle
+
+@DslMarker
+annotation class BuildKonfigDsl

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigExtension.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigExtension.kt
@@ -3,20 +3,29 @@ package com.codingfeline.buildkonfig.gradle
 import com.codingfeline.buildkonfig.compiler.DEFAULT_KONFIG_OBJECT_NAME
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.api.Project
+import org.gradle.api.logging.Logger
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import javax.inject.Inject
 
-open class BuildKonfigExtension(
-    private val project: Project
+@BuildKonfigDsl
+abstract class BuildKonfigExtension @Inject constructor(
+    private val objects: ObjectFactory,
+    private val logger: Logger,
 ) {
 
-    private val configFactory = TargetConfigFactory(project.objects, project.logger)
+    abstract val packageName: Property<String>
+    abstract val objectName: Property<String>
+    abstract val exposeObjectWithName: Property<String>
 
-    var packageName: String? = null
-    var objectName: String = DEFAULT_KONFIG_OBJECT_NAME
-    var exposeObjectWithName: String? = null
+    val defaultConfigs: MutableMap<String, TargetConfigDsl> = mutableMapOf()
+    val targetConfigs: MutableMap<String, NamedDomainObjectContainer<TargetConfigDsl>> = mutableMapOf()
 
-    val defaultConfigs = mutableMapOf<String, TargetConfigDsl>()
-    val targetConfigs = mutableMapOf<String, NamedDomainObjectContainer<TargetConfigDsl>>()
+    private val configFactory = TargetConfigFactory(objects, logger)
+
+    init {
+        objectName.convention(DEFAULT_KONFIG_OBJECT_NAME)
+    }
 
     @Suppress("unused")
     fun defaultConfigs(config: Action<TargetConfigDsl>) {
@@ -50,15 +59,9 @@ open class BuildKonfigExtension(
         container.forEach { it.flavor = flavor }
     }
 
-    private fun createNewTargetConfig(): TargetConfigDsl {
-        return project.objects.newInstance(
-            TargetConfigDsl::class.java,
-            "defaults",
-            project.logger
-        )
-    }
+    private fun createNewTargetConfig(): TargetConfigDsl =
+        objects.newInstance(TargetConfigDsl::class.java, "defaults", logger)
 
-    private fun createTargetConfigContainer(): NamedDomainObjectContainer<TargetConfigDsl> {
-        return project.container(TargetConfigDsl::class.java, configFactory)
-    }
+    private fun createTargetConfigContainer(): NamedDomainObjectContainer<TargetConfigDsl> =
+        objects.domainObjectContainer(TargetConfigDsl::class.java, configFactory)
 }

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -46,8 +46,6 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
 
         val mppExtension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
 
-        val flavorProvider = project.flavorProvider()
-
         // Register the task eagerly (outside afterEvaluate) so its outputs participate in
         // Gradle's task graph as Providers from the start. This is what allows downstream
         // tasks (e.g. KSP under Gradle 9.0) to discover an implicit dependency edge through
@@ -68,14 +66,18 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
             it.exposeObject.set(
                 extension.exposeObjectWithName.map { it.isNotBlank() }.orElse(false)
             )
-            it.flavor.set(flavorProvider)
         }
 
         // A single, flat afterEvaluate is used purely to compute the merged configuration
         // (which depends on extension DSL evaluation and KMP target registration completing)
         // and to wire generated source directories into Kotlin source sets.
         project.afterEvaluate {
-            val flavor = flavorProvider.get()
+            // Resolve the flavor here (not via a Provider chain) so that callers can influence
+            // it from the build script via project.ext.set(...) / project.setProperty(...) /
+            // gradle.taskGraph hooks before this afterEvaluate runs. The resolved value is
+            // then captured as a String constant on the task input, which is configuration-
+            // cache-safe.
+            val flavor = project.findFlavor()
 
             val mergedConfigs = extension.mergeConfigs(project.logger.toBuildKonfigLogger(), flavor)
                 ?: return@afterEvaluate
@@ -94,6 +96,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
                 decideOutputs(project, mppExtension, targetConfigs, outputDirectory, forceExpectActual)
 
             task.configure { t ->
+                t.flavor.set(flavor)
                 t.hasJsTarget.set(hasJsTarget)
                 t.targetConfigFiles.set(targetConfigSources.mapValues { (_, value) -> value.configFile })
             }
@@ -179,8 +182,15 @@ fun decideOutputs(
         }
 }
 
-internal fun Project.flavorProvider(): Provider<String> =
-    providers.gradleProperty(FLAVOR_PROPERTY).orElse(DEFAULT_FLAVOR)
+internal fun Project.findFlavor(): String {
+    val flavor = findProperty(FLAVOR_PROPERTY) ?: ""
+    return if (flavor is String) {
+        flavor
+    } else {
+        logger.error("$FLAVOR_PROPERTY must be string. Fallback to non-flavored config: ${flavor::class.java}")
+        DEFAULT_FLAVOR
+    }
+}
 
 internal fun Logger.toBuildKonfigLogger(): BuildKonfigLogger {
     return BuildKonfigLogger { level, message ->

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -26,7 +26,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
     private var isMultiplatform = false
 
     override fun apply(target: Project) {
-        val extension = target.extensions.create("buildkonfig", BuildKonfigExtension::class.java, target)
+        val extension = target.extensions.create("buildkonfig", BuildKonfigExtension::class.java, target.logger)
 
         target.plugins.withType(KotlinMultiplatformPluginWrapper::class.java) {
             isMultiplatform = true
@@ -46,6 +46,8 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
 
         val mppExtension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
 
+        val flavorProvider = project.flavorProvider()
+
         // Register the task eagerly (outside afterEvaluate) so its outputs participate in
         // Gradle's task graph as Providers from the start. This is what allows downstream
         // tasks (e.g. KSP under Gradle 9.0) to discover an implicit dependency edge through
@@ -53,23 +55,34 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         val task = project.tasks.register("generateBuildKonfig", BuildKonfigTask::class.java) {
             it.group = "buildkonfig"
             it.description = "generate BuildKonfig"
+
+            // Wire singleton DSL fields as Provider-to-Provider so the values are read lazily
+            // at task execution time. Required inputs (e.g. packageName) surface as native
+            // Gradle errors via @get:Input on the task if left unset.
+            it.packageName.set(extension.packageName)
+            it.objectName.set(
+                extension.objectName.zip(extension.exposeObjectWithName.orElse("")) { obj, exposed ->
+                    if (exposed.isNotBlank()) exposed else obj
+                }
+            )
+            it.exposeObject.set(
+                extension.exposeObjectWithName.map { it.isNotBlank() }.orElse(false)
+            )
+            it.flavor.set(flavorProvider)
         }
 
         // A single, flat afterEvaluate is used purely to compute the merged configuration
         // (which depends on extension DSL evaluation and KMP target registration completing)
         // and to wire generated source directories into Kotlin source sets.
-        project.afterEvaluate { p ->
-            val flavor = p.findFlavor()
+        project.afterEvaluate {
+            val flavor = flavorProvider.get()
 
             val mergedConfigs = extension.mergeConfigs(project.logger.toBuildKonfigLogger(), flavor)
                 ?: return@afterEvaluate
 
             val targetConfigs = mergedConfigs.toMutableMap()
 
-            val exposedName = extension.exposeObjectWithName.takeIf { !it.isNullOrBlank() }
-            val exposeObject = exposedName != null
-            val objectName = exposedName ?: extension.objectName
-            require(objectName.isNotBlank()) { "objectName must not be blank" }
+            val exposeObject = extension.exposeObjectWithName.getOrElse("").isNotBlank()
 
             // When both js and wasm targets exist with exposeObject, force expect/actual generation
             // so that @JsExport is only added to the JS actual (wasmJs doesn't support @JsExport on objects).
@@ -81,11 +94,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
                 decideOutputs(project, mppExtension, targetConfigs, outputDirectory, forceExpectActual)
 
             task.configure { t ->
-                t.packageName.set(requireNotNull(extension.packageName) { "packageName must be provided" })
-                t.objectName.set(objectName)
-                t.exposeObject.set(exposeObject)
                 t.hasJsTarget.set(hasJsTarget)
-                t.flavor.set(flavor)
                 t.targetConfigFiles.set(targetConfigSources.mapValues { (_, value) -> value.configFile })
             }
 
@@ -170,15 +179,8 @@ fun decideOutputs(
         }
 }
 
-internal fun Project.findFlavor(): String {
-    val flavor = findProperty(FLAVOR_PROPERTY) ?: ""
-    return if (flavor is String) {
-        flavor
-    } else {
-        logger.error("$FLAVOR_PROPERTY must be string. Fallback to non-flavored config: ${flavor::class.java}")
-        DEFAULT_FLAVOR
-    }
-}
+internal fun Project.flavorProvider(): Provider<String> =
+    providers.gradleProperty(FLAVOR_PROPERTY).orElse(DEFAULT_FLAVOR)
 
 internal fun Logger.toBuildKonfigLogger(): BuildKonfigLogger {
     return BuildKonfigLogger { level, message ->

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/TargetConfigDsl.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/TargetConfigDsl.kt
@@ -6,6 +6,7 @@ import org.gradle.api.logging.Logger
 import java.io.Serializable
 import javax.inject.Inject
 
+@BuildKonfigDsl
 open class TargetConfigDsl @Inject constructor(
     name: String,
     private val logger: Logger


### PR DESCRIPTION
## Summary

Closes #293.

Convert `BuildKonfigExtension` to an abstract Gradle-managed type whose public DSL fields are `Property<String>` instead of mutable Kotlin `var`s. The plugin wires task inputs as Provider-to-Provider rather than resolving extension values eagerly inside `afterEvaluate`, and adds a `@BuildKonfigDsl` marker so nested DSL scopes are isolated.

### What changed

- `packageName`, `objectName`, `exposeObjectWithName` are now `abstract val Property<String>`. `objectName` uses `convention(DEFAULT_KONFIG_OBJECT_NAME)`; the other two are required / optional Properties.
- `BuildKonfigPlugin` wires task inputs as `task.x.set(extension.x)` Providers at task registration time. Custom `requireNotNull(packageName)` / `require(objectName.isNotBlank())` checks are dropped; a missing `packageName` now surfaces as Gradle's native \"Cannot query the value of this property\" error.
- New `@BuildKonfigDsl` `@DslMarker` annotation, applied to `BuildKonfigExtension` and `TargetConfigDsl`.
- `findFlavor()` is preserved as `Project.findProperty(FLAVOR_PROPERTY)` so that build scripts can continue to inject the flavor via `project.extensions.extraProperties.set(...)` / `project.setProperty(...)`. The resolved value is captured as a String constant on the task input inside `afterEvaluate`, so configuration cache compatibility is unchanged.

### Breaking changes

The DSL surface is unchanged for the common cases (`packageName = \"...\"` / `objectName = \"...\"` continue to work in both Groovy and Kotlin DSL). However, the extension is now an abstract class with abstract `Property` fields, so:

- Kotlin DSL consumers on Gradle older than 8.2 must use `packageName.set(\"...\")` (lazy property assignment via `=` requires Gradle 8.2+). Groovy DSL is unaffected.
- Anything that used to read `extension.packageName` as `String?` directly (subprojects extending the plugin, etc.) needs to use `extension.packageName.orNull` / `.get()`.

### Out of scope

- Multiple top-level configs / multiple generated objects (#75).
- Non-multiplatform Kotlin plugin support (#40). This refactor is a prerequisite that will make that work cleaner, but the actual non-KMP wiring is a separate change.

## Test plan

- [x] `./gradlew :buildkonfig-gradle-plugin:test` — all 32 tests pass, including HMPP, flavor, Kotlin DSL, const fields, and Gradle 9 KSP variants.
- [x] `BuildKonfigPluginConfigurationCacheTest` continues to pass (configuration cache entry stored on first run, reused on second run).
- [x] `BuildKonfigPluginFlavorTest > changing flavor between builds re-runs the task with the new flavor value` continues to pass, confirming the flavor value correctly propagates as a task input.
- [x] Probed end-to-end with a sample project that mimics the Android product-flavor pattern: `gradle assembleStagingRelease` triggers `project.ext.set(\"buildkonfig.flavor\", \"staging\")` from the build script, and the generated `BuildKonfig.kt` picks up the staging flavor as expected. Configuration cache stores on first run and is reused on second run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)