### PR TITLE
feat: support standalone Kotlin/JVM and Kotlin/JS projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ BuildKonfig
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.codingfeline.buildkonfig/buildkonfig-gradle-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.codingfeline.buildkonfig/buildkonfig-gradle-plugin)
 
-BuildConfig for Kotlin Multiplatform Project.  
+BuildConfig for Kotlin Multiplatform, Kotlin/JVM, and Kotlin/JS projects.  
 It currently supports embedding values from gradle file.
 
 ## Table Of Contents
@@ -12,6 +12,7 @@ It currently supports embedding values from gradle file.
 - [Usage](#usage)
     - [Requirements](#requirements)
     - [Gradle Configuration](#gradle-configuration)
+    - [Non-multiplatform projects](#non-multiplatform-projects)
     - [Product Flavor?](#product-flavor)
     - [Overwriting Values](#overwriting-values)
     - [HMPP](#hmpp)
@@ -36,7 +37,7 @@ Rather I'd like to do it once.
 ### Requirements
 
 - Kotlin **2.1.0** or later
-- Kotlin Multiplatform Project
+- One of: Kotlin Multiplatform, Kotlin/JVM, or Kotlin/JS plugin applied to the project
 - Gradle 8 or later
 
 <a name="gradle-configuration"/>
@@ -298,6 +299,66 @@ internal actual object BuildKonfig {
     actual val nullableField: String? = null
 }
 ```
+
+<a name="non-multiplatform-projects"/>
+
+### Non-multiplatform projects
+
+BuildKonfig also works on standalone Kotlin/JVM and Kotlin/JS projects.
+Apply `org.jetbrains.kotlin.jvm` or `org.jetbrains.kotlin.js` instead of multiplatform, and use the same `buildkonfig { ... }` block.
+
+<details open>
+<summary>Kotlin DSL</summary>
+
+```kotlin
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
+
+plugins {
+    kotlin("jvm")
+    id("com.codingfeline.buildkonfig")
+}
+
+buildkonfig {
+    packageName = "com.example.app"
+
+    defaultConfigs {
+        buildConfigField(STRING, "name", "value")
+    }
+}
+```
+
+</details>
+
+<details>
+<summary>Groovy DSL</summary>
+
+```gradle
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.codingfeline.buildkonfig'
+
+buildkonfig {
+    packageName = 'com.example.app'
+
+    defaultConfigs {
+        buildConfigField 'STRING', 'name', 'value'
+    }
+}
+```
+
+</details>
+
+A single concrete object is generated into the `main` source set — there is no `expect`/`actual` split, since there is only one target.
+
+```kotlin
+// src/main/kotlin (generated)
+package com.example.app
+
+internal object BuildKonfig {
+    val name: String = "value"
+}
+```
+
+For Kotlin/JS projects, `@JsExport` is auto-added when `exposeObjectWithName` is set, exactly like the multiplatform path. The `defaultConfigs` block (including flavors) is fully supported. `targetConfigs` are not meaningful for a single-target project; if you declare them, a warning is logged and they are ignored.
 
 <a name="product-flavor"/>
 

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -66,6 +66,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
             it.exposeObject.set(
                 extension.exposeObjectWithName.map { it.isNotBlank() }.orElse(false)
             )
+            it.commonSourceSetName.set(COMMON_SOURCESET_NAME)
         }
 
         // A single, flat afterEvaluate is used purely to compute the merged configuration

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -95,11 +95,6 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
     ) {
         val outputDirectory = project.layout.buildDirectory.dir("buildkonfig")
 
-        // Resolve the flavor here (not via a Provider chain) so that callers can influence
-        // it from the build script via project.ext.set(...) / project.setProperty(...) /
-        // gradle.taskGraph hooks before this afterEvaluate runs. The resolved value is
-        // then captured as a String constant on the task input, which is configuration-
-        // cache-safe.
         val flavor = project.findFlavor()
 
         val mergedConfigs = extension.mergeConfigs(project.logger.toBuildKonfigLogger(), flavor)
@@ -261,6 +256,15 @@ fun decideOutputs(
         }
 }
 
+/**
+ * Resolves the BuildKonfig flavor from project properties.
+ *
+ * Uses [Project.findProperty] (rather than [org.gradle.api.provider.ProviderFactory.gradleProperty])
+ * so that callers can influence the flavor from the build script — e.g. by inspecting
+ * `gradle.startParameter.taskNames` and calling `project.extensions.extraProperties.set(...)` —
+ * before any `afterEvaluate` block runs. Resolution happens once during configuration and the
+ * result is captured as a String constant on the task input, so configuration cache is unaffected.
+ */
 internal fun Project.findFlavor(): String {
     val flavor = findProperty(FLAVOR_PROPERTY) ?: ""
     return if (flavor is String) {

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -103,7 +103,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
 
             targetConfigSources.forEach { (key, configSource) ->
                 val outputDirs = task.map { t -> listOfNotNull(t.outputDirectories[key]) }
-                configSource.sourceSet.kotlin.srcDirs(outputDirs)
+                configSource.registerSourceDir(outputDirs)
             }
         }
     }
@@ -152,7 +152,7 @@ fun decideOutputs(
                         outputDirectory = outputDirectory.map { it.dir(firstDependent.name) }.get().asFile,
                         config = targetConfigs.getValue(firstDependent.name)
                     ),
-                    sourceSet = firstDependent
+                    registerSourceDir = { dir -> firstDependent.kotlin.srcDirs(dir) }
                 )
 
                 return@fold acc + (firstDependent.name to tcs)
@@ -175,7 +175,7 @@ fun decideOutputs(
                     outputDirectory = outputDirectory.map { it.dir(targetSourceSet.name) }.get().asFile,
                     config = targetConfigs[source.name] ?: targetConfigs.getValue(COMMON_SOURCESET_NAME).copy(),
                 ),
-                sourceSet = targetSourceSet
+                registerSourceDir = { dir -> targetSourceSet.kotlin.srcDirs(dir) }
             )
 
             acc + (source.name to tcs)

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -12,6 +12,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
+import java.io.File
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -100,8 +101,6 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         val mergedConfigs = extension.mergeConfigs(project.logger.toBuildKonfigLogger(), flavor)
             ?: return
 
-        val targetConfigs = mergedConfigs.toMutableMap()
-
         val exposeObject = extension.exposeObjectWithName.getOrElse("").isNotBlank()
 
         // When both js and wasm targets exist with exposeObject, force expect/actual generation
@@ -111,7 +110,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         val forceExpectActual = exposeObject && hasJsTarget && hasWasmTarget
 
         val targetConfigSources =
-            decideOutputs(project, mppExtension, targetConfigs, outputDirectory, forceExpectActual)
+            decideOutputs(project, mppExtension, mergedConfigs, outputDirectory, forceExpectActual)
 
         task.configure { t ->
             t.flavor.set(flavor)
@@ -166,7 +165,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         val outputDirectory = project.layout.buildDirectory.dir("buildkonfig")
         val targetConfigFile = TargetConfigFileImpl(
             targetName = TargetName(MAIN_SOURCESET_NAME, platformType.toPlatformType()),
-            outputDirectory = outputDirectory.map { it.dir(MAIN_SOURCESET_NAME) }.get().asFile,
+            outputDirectory = outputDirectory.subdirAsFile(MAIN_SOURCESET_NAME),
             config = mainConfig,
         )
 
@@ -186,7 +185,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
 fun decideOutputs(
     project: Project,
     mppExtension: KotlinMultiplatformExtension,
-    targetConfigs: MutableMap<String, TargetConfig>,
+    targetConfigs: Map<String, TargetConfig>,
     outputDirectory: Provider<Directory>,
     forceExpectActual: Boolean = false
 ): Map<String, TargetConfigSource> {
@@ -223,7 +222,7 @@ fun decideOutputs(
                     name = firstDependent.name,
                     configFile = TargetConfigFileImpl(
                         targetName = TargetName(firstDependent.name, source.type.toPlatformType()),
-                        outputDirectory = outputDirectory.map { it.dir(firstDependent.name) }.get().asFile,
+                        outputDirectory = outputDirectory.subdirAsFile(firstDependent.name),
                         config = targetConfigs.getValue(firstDependent.name)
                     ),
                     registerSourceDir = { dir -> firstDependent.kotlin.srcDirs(dir) }
@@ -246,7 +245,7 @@ fun decideOutputs(
                 name = source.name,
                 configFile = TargetConfigFileImpl(
                     targetName = TargetName(source.name, source.type.toPlatformType()),
-                    outputDirectory = outputDirectory.map { it.dir(targetSourceSet.name) }.get().asFile,
+                    outputDirectory = outputDirectory.subdirAsFile(targetSourceSet.name),
                     config = targetConfigs[source.name] ?: targetConfigs.getValue(COMMON_SOURCESET_NAME).copy(),
                 ),
                 registerSourceDir = { dir -> targetSourceSet.kotlin.srcDirs(dir) }
@@ -274,6 +273,14 @@ internal fun Project.findFlavor(): String {
         DEFAULT_FLAVOR
     }
 }
+
+/**
+ * Eagerly resolves a named subdirectory of this directory provider as a [File]. The eager
+ * resolution is intentional — the result is captured as a task input at configuration time
+ * so that downstream tasks can pick it up via the source-set Provider chain.
+ */
+private fun Provider<Directory>.subdirAsFile(name: String): File =
+    map { it.dir(name) }.get().asFile
 
 internal fun Logger.toBuildKonfigLogger(): BuildKonfigLogger {
     return BuildKonfigLogger { level, message ->

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -11,41 +11,47 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.dsl.KotlinJsProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 
 typealias Flavor = String
 
 const val DEFAULT_FLAVOR: Flavor = ""
 const val COMMON_SOURCESET_NAME = "commonMain"
+const val MAIN_SOURCESET_NAME = "main"
 
 @Suppress("unused")
 abstract class BuildKonfigPlugin : Plugin<Project> {
 
-    private var isMultiplatform = false
+    private var configured = false
 
     override fun apply(target: Project) {
         val extension = target.extensions.create("buildkonfig", BuildKonfigExtension::class.java, target.logger)
 
-        target.plugins.withType(KotlinMultiplatformPluginWrapper::class.java) {
-            isMultiplatform = true
+        // Detect any supported Kotlin plugin (multiplatform / jvm / js / android).
+        // KotlinBasePlugin is the common interface implemented by all Kotlin compiler
+        // plugin wrappers, so this fires once for whichever Kotlin plugin the user applied.
+        target.plugins.withType(KotlinBasePlugin::class.java) {
+            if (configured) return@withType
+            configured = true
             configure(target, extension)
         }
 
         target.afterEvaluate {
-            check(isMultiplatform) {
+            check(configured) {
                 "BuildKonfig Gradle plugin applied in project '${target.path}' " +
-                    "but no supported Kotlin multiplatform plugin was found"
+                    "but no supported Kotlin plugin was found. " +
+                    "Apply one of: kotlin-multiplatform, kotlin-jvm, or kotlin-js."
             }
         }
     }
 
     private fun configure(project: Project, extension: BuildKonfigExtension) {
-        val outputDirectory = project.layout.buildDirectory.dir("buildkonfig")
-
-        val mppExtension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
-
         // Register the task eagerly (outside afterEvaluate) so its outputs participate in
         // Gradle's task graph as Providers from the start. This is what allows downstream
         // tasks (e.g. KSP under Gradle 9.0) to discover an implicit dependency edge through
@@ -66,47 +72,119 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
             it.exposeObject.set(
                 extension.exposeObjectWithName.map { it.isNotBlank() }.orElse(false)
             )
-            it.commonSourceSetName.set(COMMON_SOURCESET_NAME)
         }
 
-        // A single, flat afterEvaluate is used purely to compute the merged configuration
-        // (which depends on extension DSL evaluation and KMP target registration completing)
-        // and to wire generated source directories into Kotlin source sets.
+        // The merge / source-set wiring depends on whether this is a multiplatform project
+        // or a single-target Kotlin project. Both code paths run in afterEvaluate so the
+        // user's DSL block and any KMP target registrations have already completed.
         project.afterEvaluate {
-            // Resolve the flavor here (not via a Provider chain) so that callers can influence
-            // it from the build script via project.ext.set(...) / project.setProperty(...) /
-            // gradle.taskGraph hooks before this afterEvaluate runs. The resolved value is
-            // then captured as a String constant on the task input, which is configuration-
-            // cache-safe.
-            val flavor = project.findFlavor()
-
-            val mergedConfigs = extension.mergeConfigs(project.logger.toBuildKonfigLogger(), flavor)
-                ?: return@afterEvaluate
-
-            val targetConfigs = mergedConfigs.toMutableMap()
-
-            val exposeObject = extension.exposeObjectWithName.getOrElse("").isNotBlank()
-
-            // When both js and wasm targets exist with exposeObject, force expect/actual generation
-            // so that @JsExport is only added to the JS actual (wasmJs doesn't support @JsExport on objects).
-            val hasJsTarget = mppExtension.targets.any { t -> t.platformType == KotlinPlatformType.js }
-            val hasWasmTarget = mppExtension.targets.any { t -> t.platformType == KotlinPlatformType.wasm }
-            val forceExpectActual = exposeObject && hasJsTarget && hasWasmTarget
-
-            val targetConfigSources =
-                decideOutputs(project, mppExtension, targetConfigs, outputDirectory, forceExpectActual)
-
-            task.configure { t ->
-                t.flavor.set(flavor)
-                t.hasJsTarget.set(hasJsTarget)
-                t.targetConfigFiles.set(targetConfigSources.mapValues { (_, value) -> value.configFile })
-            }
-
-            targetConfigSources.forEach { (key, configSource) ->
-                val outputDirs = task.map { t -> listOfNotNull(t.outputDirectories[key]) }
-                configSource.registerSourceDir(outputDirs)
+            val mppExtension = project.extensions.findByType(KotlinMultiplatformExtension::class.java)
+            if (mppExtension != null) {
+                configureMultiplatform(project, extension, task, mppExtension)
+            } else {
+                configureSinglePlatform(project, extension, task)
             }
         }
+    }
+
+    private fun configureMultiplatform(
+        project: Project,
+        extension: BuildKonfigExtension,
+        task: TaskProvider<BuildKonfigTask>,
+        mppExtension: KotlinMultiplatformExtension,
+    ) {
+        val outputDirectory = project.layout.buildDirectory.dir("buildkonfig")
+
+        // Resolve the flavor here (not via a Provider chain) so that callers can influence
+        // it from the build script via project.ext.set(...) / project.setProperty(...) /
+        // gradle.taskGraph hooks before this afterEvaluate runs. The resolved value is
+        // then captured as a String constant on the task input, which is configuration-
+        // cache-safe.
+        val flavor = project.findFlavor()
+
+        val mergedConfigs = extension.mergeConfigs(project.logger.toBuildKonfigLogger(), flavor)
+            ?: return
+
+        val targetConfigs = mergedConfigs.toMutableMap()
+
+        val exposeObject = extension.exposeObjectWithName.getOrElse("").isNotBlank()
+
+        // When both js and wasm targets exist with exposeObject, force expect/actual generation
+        // so that @JsExport is only added to the JS actual (wasmJs doesn't support @JsExport on objects).
+        val hasJsTarget = mppExtension.targets.any { t -> t.platformType == KotlinPlatformType.js }
+        val hasWasmTarget = mppExtension.targets.any { t -> t.platformType == KotlinPlatformType.wasm }
+        val forceExpectActual = exposeObject && hasJsTarget && hasWasmTarget
+
+        val targetConfigSources =
+            decideOutputs(project, mppExtension, targetConfigs, outputDirectory, forceExpectActual)
+
+        task.configure { t ->
+            t.flavor.set(flavor)
+            t.hasJsTarget.set(hasJsTarget)
+            t.commonSourceSetName.set(COMMON_SOURCESET_NAME)
+            t.targetConfigFiles.set(targetConfigSources.mapValues { (_, value) -> value.configFile })
+        }
+
+        targetConfigSources.forEach { (key, configSource) ->
+            val outputDirs = task.map { t -> listOfNotNull(t.outputDirectories[key]) }
+            configSource.registerSourceDir(outputDirs)
+        }
+    }
+
+    private fun configureSinglePlatform(
+        project: Project,
+        extension: BuildKonfigExtension,
+        task: TaskProvider<BuildKonfigTask>,
+    ) {
+        val kotlinExtension = project.extensions.findByType(KotlinProjectExtension::class.java) ?: return
+
+        val platformType = when (kotlinExtension) {
+            is KotlinJvmProjectExtension -> KotlinPlatformType.jvm
+            is KotlinJsProjectExtension -> KotlinPlatformType.js
+            else -> {
+                project.logger.warn(
+                    "BuildKonfig: unsupported Kotlin extension '${kotlinExtension::class.java.simpleName}'. " +
+                        "Skipping code generation."
+                )
+                return
+            }
+        }
+
+        if (extension.targetConfigs.isNotEmpty()) {
+            project.logger.warn(
+                "BuildKonfig: targetConfigs are ignored in non-multiplatform projects (project '${project.path}'). " +
+                    "Use defaultConfigs instead."
+            )
+        }
+
+        val flavor = project.findFlavor()
+        val mergedConfigs = extension.mergeConfigs(
+            project.logger.toBuildKonfigLogger(),
+            flavor,
+            commonSourceSetName = MAIN_SOURCESET_NAME,
+        ) ?: return
+
+        // For non-KMP projects there is exactly one source set ("main"). Drop any
+        // target-specific entries (the user was already warned) so the task generates a
+        // single concrete object rather than an expect/actual pair.
+        val mainConfig = mergedConfigs.getValue(MAIN_SOURCESET_NAME)
+        val outputDirectory = project.layout.buildDirectory.dir("buildkonfig")
+        val targetConfigFile = TargetConfigFileImpl(
+            targetName = TargetName(MAIN_SOURCESET_NAME, platformType.toPlatformType()),
+            outputDirectory = outputDirectory.map { it.dir(MAIN_SOURCESET_NAME) }.get().asFile,
+            config = mainConfig,
+        )
+
+        task.configure { t ->
+            t.flavor.set(flavor)
+            t.hasJsTarget.set(platformType == KotlinPlatformType.js)
+            t.commonSourceSetName.set(MAIN_SOURCESET_NAME)
+            t.targetConfigFiles.set(mapOf(MAIN_SOURCESET_NAME to targetConfigFile))
+        }
+
+        val mainSourceSet = kotlinExtension.sourceSets.getByName(MAIN_SOURCESET_NAME)
+        val outputDirs = task.map { t -> listOfNotNull(t.outputDirectories[MAIN_SOURCESET_NAME]) }
+        mainSourceSet.kotlin.srcDirs(outputDirs)
     }
 }
 

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpec.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpec.kt
@@ -5,15 +5,21 @@ import com.codingfeline.buildkonfig.compiler.FieldSpec
 import com.codingfeline.buildkonfig.compiler.TargetConfig
 import com.codingfeline.buildkonfig.compiler.TargetConfigFile
 import com.codingfeline.buildkonfig.compiler.TargetName
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import java.io.File
 
 data class TargetConfigSource(
     val name: String,
     val configFile: TargetConfigFileImpl,
-    val sourceSet: KotlinSourceSet,
+    /**
+     * Wires the generated source directory into the appropriate Kotlin source set.
+     * Encapsulated as a callback so the call site does not need to know whether the
+     * underlying source set comes from a KMP target, a standalone Kotlin/JVM project,
+     * a standalone Kotlin/JS project, etc.
+     */
+    val registerSourceDir: (Provider<List<File>>) -> Unit,
 )
 
 data class TargetConfigFileImpl(

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpec.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpec.kt
@@ -30,7 +30,8 @@ data class TargetConfigFileImpl(
 
 fun BuildKonfigExtension.mergeConfigs(
     logger: BuildKonfigLogger,
-    flavor: Flavor = DEFAULT_FLAVOR
+    flavor: Flavor = DEFAULT_FLAVOR,
+    commonSourceSetName: String = COMMON_SOURCESET_NAME,
 ): Map<String, TargetConfig>? {
     if (!defaultConfigs.containsKey(DEFAULT_FLAVOR)) {
         logger.warn("BuildKonfig: non-flavored defaultConfigs is not provided. Skipping code generation.")
@@ -48,7 +49,7 @@ fun BuildKonfigExtension.mergeConfigs(
                 defaultConfig,
                 checkTargetSpecificFields(defaultConfig, config)
             )
-        } + (COMMON_SOURCESET_NAME to defaultConfig)
+        } + (commonSourceSetName to defaultConfig)
 }
 
 fun checkTargetSpecificFields(defaultConfig: TargetConfig, targetConfig: TargetConfig): TargetConfig {

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
@@ -37,6 +37,14 @@ abstract class BuildKonfigTask : DefaultTask() {
     @get:Input
     abstract val flavor: Property<String>
 
+    /**
+     * Name of the source set whose merged config is treated as the "common" config.
+     * - KMP projects: `commonMain` (the default).
+     * - Non-KMP projects: typically `main`, since there is no expect/actual split.
+     */
+    @get:Input
+    abstract val commonSourceSetName: Property<String>
+
     @get:Nested
     abstract val targetConfigFiles: MapProperty<String, TargetConfigFileImpl>
 
@@ -48,9 +56,10 @@ abstract class BuildKonfigTask : DefaultTask() {
     @Suppress("unused")
     @TaskAction
     fun generateBuildKonfigFiles() {
+        val commonName = commonSourceSetName.get()
         val outputDirs = outputDirectories
         // clean up output directories
-        outputDirs.getValue(COMMON_SOURCESET_NAME).parentFile.cleanupDirectory()
+        outputDirs.getValue(commonName).parentFile.cleanupDirectory()
         outputDirs.forEach { it.value.mkdirs() }
 
         val configFiles = targetConfigFiles.get()
@@ -58,8 +67,8 @@ abstract class BuildKonfigTask : DefaultTask() {
             packageName = packageName.get(),
             objectName = objectName.get(),
             exposeObject = exposeObject.get(),
-            commonConfig = configFiles.getValue(COMMON_SOURCESET_NAME),
-            targetConfigs = configFiles.filter { it.key != COMMON_SOURCESET_NAME }.values.toList(),
+            commonConfig = configFiles.getValue(commonName),
+            targetConfigs = configFiles.filter { it.key != commonName }.values.toList(),
             hasJsTarget = hasJsTarget.get()
         )
 

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginNonKmpTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginNonKmpTest.kt
@@ -207,6 +207,47 @@ class BuildKonfigPluginNonKmpTest {
     }
 
     @Test
+    fun `non-KMP JVM project is compatible with Configuration Cache`() {
+        buildFile.writeText(
+            """
+            |$jvmBuildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.sample"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'env', 'production'
+            |   }
+            |}
+            """.trimMargin()
+        )
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        val firstRun = runner
+            .withArguments(
+                "generateBuildKonfig",
+                "--configuration-cache",
+                "--configuration-cache-problems=fail",
+                "--stacktrace",
+            )
+            .build()
+        assertThat(firstRun.output).contains("Configuration cache entry stored")
+
+        val secondRun = runner
+            .withArguments(
+                "generateBuildKonfig",
+                "--configuration-cache",
+                "--configuration-cache-problems=fail",
+                "--stacktrace",
+            )
+            .build()
+        assertThat(secondRun.output).contains("Configuration cache entry reused")
+    }
+
+    @Test
     fun `targetConfigs are ignored with a warning on a non-KMP project`() {
         buildFile.writeText(
             """

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginNonKmpTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginNonKmpTest.kt
@@ -1,0 +1,253 @@
+package com.codingfeline.buildkonfig.gradle
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class BuildKonfigPluginNonKmpTest {
+
+    @get:Rule
+    val projectDir = TemporaryFolder()
+
+    lateinit var buildFile: File
+
+    lateinit var settingFile: File
+
+    private val jvmBuildFileHeader = """
+        |plugins {
+        |    id 'org.jetbrains.kotlin.jvm'
+        |    id 'com.codingfeline.buildkonfig'
+        |}
+        |
+        |repositories {
+        |   mavenCentral()
+        |}
+        |
+    """.trimMargin()
+
+    @Before
+    fun setup() {
+        buildFile = projectDir.newFile("build.gradle")
+        settingFile = projectDir.newFile("settings.gradle")
+        settingFile.writeText(settingsGradle)
+    }
+
+    @Test
+    fun `Applying plugin to a Kotlin JVM project generates a single concrete object`() {
+        buildFile.writeText(
+            """
+            |$jvmBuildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.sample"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'env', 'production'
+            |       buildConfigField 'INT', 'version', '42'
+            |   }
+            |}
+            """.trimMargin()
+        )
+
+        val buildDir = File(projectDir.root, "build/buildkonfig")
+        buildDir.deleteRecursively()
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        val result = runner
+            .withArguments("generateBuildKonfig", "--stacktrace")
+            .build()
+
+        assertThat(result.output).contains("BUILD SUCCESSFUL")
+
+        val generated = File(buildDir, "main/com/sample/BuildKonfig.kt")
+        assertThat(generated.exists()).isTrue()
+        val content = generated.readText()
+        assertThat(content).contains("internal object BuildKonfig")
+        assertThat(content).contains("public val env: String = \"production\"")
+        assertThat(content).contains("public val version: Int = 42")
+        // No expect/actual generation for non-KMP projects.
+        assertThat(content).doesNotContain("expect ")
+        assertThat(content).doesNotContain("actual ")
+    }
+
+    @Test
+    fun `compileKotlin picks up the generated source on a Kotlin JVM project`() {
+        buildFile.writeText(
+            """
+            |$jvmBuildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.sample"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'env', 'production'
+            |   }
+            |}
+            """.trimMargin()
+        )
+
+        // Write a source file that references the generated BuildKonfig object so that
+        // the kotlin compilation will fail unless the generated source dir was wired
+        // into the JVM main source set.
+        val srcDir = projectDir.newFolder("src", "main", "kotlin", "com", "sample")
+        File(srcDir, "Usage.kt").writeText(
+            """
+            package com.sample
+
+            fun consumeEnv(): String = BuildKonfig.env
+            """.trimIndent()
+        )
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        val result = runner
+            .withArguments("compileKotlin", "--stacktrace")
+            .build()
+
+        assertThat(result.output).contains("BUILD SUCCESSFUL")
+    }
+
+    @Test
+    fun `flavor selection works on a Kotlin JVM project`() {
+        buildFile.writeText(
+            """
+            |$jvmBuildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.sample"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'env', 'production'
+            |   }
+            |   defaultConfigs("staging") {
+            |       buildConfigField 'STRING', 'env', 'staging'
+            |   }
+            |}
+            """.trimMargin()
+        )
+
+        val buildDir = File(projectDir.root, "build/buildkonfig")
+        buildDir.deleteRecursively()
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        val result = runner
+            .withArguments("generateBuildKonfig", "-Pbuildkonfig.flavor=staging", "--stacktrace")
+            .build()
+
+        assertThat(result.output).contains("BUILD SUCCESSFUL")
+        val generated = File(buildDir, "main/com/sample/BuildKonfig.kt")
+        assertThat(generated.readText()).contains("public val env: String = \"staging\"")
+    }
+
+    @Test
+    fun `Applying plugin to a Kotlin JS project generates a single concrete object`() {
+        buildFile.writeText(
+            """
+            |plugins {
+            |    id 'org.jetbrains.kotlin.js'
+            |    id 'com.codingfeline.buildkonfig'
+            |}
+            |
+            |repositories {
+            |   mavenCentral()
+            |}
+            |
+            |kotlin {
+            |   js {
+            |       browser()
+            |       nodejs()
+            |       binaries.executable()
+            |   }
+            |}
+            |
+            |buildkonfig {
+            |   packageName = "com.sample"
+            |   exposeObjectWithName = "BuildKonfig"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'env', 'production'
+            |   }
+            |}
+            """.trimMargin()
+        )
+
+        // kotlin-js requires a main entry point for the executable.
+        val srcDir = projectDir.newFolder("src", "main", "kotlin")
+        File(srcDir, "Main.kt").writeText("fun main() {}")
+
+        val buildDir = File(projectDir.root, "build/buildkonfig")
+        buildDir.deleteRecursively()
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        val result = runner
+            .withArguments("generateBuildKonfig", "--stacktrace")
+            .build()
+
+        assertThat(result.output).contains("BUILD SUCCESSFUL")
+        val generated = File(buildDir, "main/com/sample/BuildKonfig.kt")
+        assertThat(generated.exists()).isTrue()
+        val content = generated.readText()
+        assertThat(content).contains("@JsExport")
+        assertThat(content).contains("public object BuildKonfig")
+    }
+
+    @Test
+    fun `targetConfigs are ignored with a warning on a non-KMP project`() {
+        buildFile.writeText(
+            """
+            |$jvmBuildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.sample"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'env', 'production'
+            |   }
+            |   targetConfigs {
+            |       jvm {
+            |           buildConfigField 'STRING', 'env', 'jvmonly'
+            |       }
+            |   }
+            |}
+            """.trimMargin()
+        )
+
+        val buildDir = File(projectDir.root, "build/buildkonfig")
+        buildDir.deleteRecursively()
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.root)
+            .withPluginClasspath()
+
+        val result = runner
+            .withArguments("generateBuildKonfig", "--stacktrace")
+            .build()
+
+        assertThat(result.output).contains("BUILD SUCCESSFUL")
+        assertThat(result.output)
+            .contains("BuildKonfig: targetConfigs are ignored in non-multiplatform projects")
+
+        val generated = File(buildDir, "main/com/sample/BuildKonfig.kt")
+        assertThat(generated.exists()).isTrue()
+        val content = generated.readText()
+        // The defaultConfigs value wins; no expect/actual was generated.
+        assertThat(content).contains("public val env: String = \"production\"")
+        assertThat(content).doesNotContain("expect ")
+        assertThat(content).doesNotContain("actual ")
+    }
+}

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginNonKmpTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginNonKmpTest.kt
@@ -17,17 +17,7 @@ class BuildKonfigPluginNonKmpTest {
 
     lateinit var settingFile: File
 
-    private val jvmBuildFileHeader = """
-        |plugins {
-        |    id 'org.jetbrains.kotlin.jvm'
-        |    id 'com.codingfeline.buildkonfig'
-        |}
-        |
-        |repositories {
-        |   mavenCentral()
-        |}
-        |
-    """.trimMargin()
+    private val jvmBuildFileHeader = buildFileHeader("org.jetbrains.kotlin.jvm")
 
     @Before
     fun setup() {

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
@@ -67,11 +67,10 @@ class BuildKonfigPluginTest {
     }
 
     @Test
-    fun `Applying plugin without KMP plugin throws`() {
+    fun `Applying plugin without any Kotlin plugin throws`() {
         buildFile.writeText(
             """
             |plugins {
-            |   id 'org.jetbrains.kotlin.jvm'
             |   id 'com.codingfeline.buildkonfig'
             |}
             |
@@ -86,8 +85,6 @@ class BuildKonfigPluginTest {
             |       buildConfigField 'STRING', 'test', 'hoge'
             |   }
             |}
-            |
-            |kotlin {}
             """.trimMargin()
         )
 
@@ -103,7 +100,7 @@ class BuildKonfigPluginTest {
             .buildAndFail()
 
         assertThat(result.output)
-            .contains("BuildKonfig Gradle plugin applied in project ':' but no supported Kotlin multiplatform plugin was found")
+            .contains("BuildKonfig Gradle plugin applied in project ':' but no supported Kotlin plugin was found")
     }
 
     @Test

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
@@ -17,17 +17,7 @@ class BuildKonfigPluginTest {
 
     lateinit var settingFile: File
 
-    private val buildFileHeader = """
-        |plugins {
-        |    id 'kotlin-multiplatform'
-        |    id 'com.codingfeline.buildkonfig'
-        |}
-        |
-        |repositories {
-        |   mavenCentral()
-        |}
-        |
-    """.trimMargin()
+    private val buildFileHeader = buildFileHeader("kotlin-multiplatform")
 
     private val buildFileMPPConfig = """
         |kotlin {

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/TestUtils.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/TestUtils.kt
@@ -14,6 +14,22 @@ fun createAndroidManifest(projectDir: TemporaryFolder, sourceSetName: String = "
 }
 
 
+/**
+ * Build script header — `plugins { ... }` plus a `mavenCentral()` repository — for the given
+ * Kotlin plugin id.
+ */
+fun buildFileHeader(kotlinPluginId: String): String = """
+            |plugins {
+            |    id '$kotlinPluginId'
+            |    id 'com.codingfeline.buildkonfig'
+            |}
+            |
+            |repositories {
+            |   mavenCentral()
+            |}
+            |
+        """.trimMargin()
+
 val settingsGradle = """
             |pluginManagement {
             |   resolutionStrategy {


### PR DESCRIPTION
## Summary

Closes #40.

Allow `buildkonfig { }` to be applied alongside `org.jetbrains.kotlin.jvm` or `org.jetbrains.kotlin.js` instead of requiring `org.jetbrains.kotlin.multiplatform`. The plugin now detects any supported Kotlin compiler plugin via `KotlinBasePlugin` and dispatches to either the existing multiplatform path or a new single-platform path:

- **Multiplatform projects**: behavior is unchanged.
- **Standalone Kotlin/JVM or Kotlin/JS projects**: a single concrete `BuildKonfig` object is generated into the project's `main` source set. No `expect` / `actual` is produced because there is only one target. For Kotlin/JS projects, `@JsExport` is still auto-added when `exposeObjectWithName` is set, mirroring the KMP behavior.

`targetConfigs` declared on a non-multiplatform project are warned about and ignored (they have no meaningful single-target interpretation). The "no Kotlin plugin applied" check is updated to mention all supported plugins instead of just multiplatform.

## What changed

- `BuildKonfigPlugin.apply` switches plugin detection from `KotlinMultiplatformPluginWrapper` to `KotlinBasePlugin`, which fires for all Kotlin compiler plugin wrappers.
- New `configureSinglePlatform` path resolves the merged default config, registers it under the `main` source set name, and wires the generated source directory into `KotlinProjectExtension.sourceSets["main"].kotlin.srcDirs(...)`.
- `BuildKonfigTask` gains a `commonSourceSetName: Property<String>` input so the task action no longer hard-codes `commonMain`.
- `BuildKonfigExtension.mergeConfigs(...)` accepts a `commonSourceSetName` parameter (defaults to `"commonMain"` for backward compatibility).
- `TargetConfigSource.sourceSet: KotlinSourceSet` is replaced with a `registerSourceDir: (Provider<List<File>>) -> Unit` callback, so the call site no longer needs to know which kind of source set it's wiring into.

## Out of scope

- Standalone `com.android.application` / `com.android.library` (without KMP). Android variants need a different code path via `AndroidComponentsExtension.onVariants { ... }`. Issue #40 reporter explicitly mentioned JVM/JS/Native; Android-only support can be a follow-up.
- Kotlin/Native standalone — the Kotlin team does not ship a standalone Native plugin; Native is only addressable via the multiplatform plugin.

## Test plan

- [x] `./gradlew :buildkonfig-gradle-plugin:test` — all tests pass (32 existing + 6 new non-KMP tests = 38 total). KMP, HMPP, flavor, Kotlin DSL, const fields, Gradle 9 KSP, configuration cache variants are all unchanged.
- [x] New `BuildKonfigPluginNonKmpTest` covers:
  - Kotlin/JVM project generates a concrete `BuildKonfig` with no `expect` / `actual`.
  - Kotlin/JS project generates a concrete `BuildKonfig` annotated with `@JsExport` when `exposeObjectWithName` is set.
  - `compileKotlin` picks up the generated source dir on a JVM project.
  - Flavor selection (`-Pbuildkonfig.flavor=staging`) works on a non-KMP project.
  - `targetConfigs { ... }` on a non-KMP project emits a warning and falls back to default-only generation.
  - Configuration Cache is honored end-to-end for the non-KMP JVM path.
- [x] The previous "throws without KMP plugin" test is renamed to "throws without any Kotlin plugin" and now applies only `com.codingfeline.buildkonfig` with no Kotlin plugin at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)