### PR TITLE
refactor: migrate remaining test files to the buildFileHeader helper

### DIFF
--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConfigurationCacheTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConfigurationCacheTest.kt
@@ -17,17 +17,7 @@ class BuildKonfigPluginConfigurationCacheTest {
 
     lateinit var settingFile: File
 
-    private val buildFileHeader = """
-        |plugins {
-        |    id 'kotlin-multiplatform'
-        |    id 'com.codingfeline.buildkonfig'
-        |}
-        |
-        |repositories {
-        |   mavenCentral()
-        |}
-        |
-    """.trimMargin()
+    private val buildFileHeader = buildFileHeader("kotlin-multiplatform")
 
     private val buildFileMPPConfig = """
         |kotlin {

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
@@ -17,17 +17,7 @@ class BuildKonfigPluginConstFieldsTest {
 
     lateinit var settingFile: File
 
-    private val buildFileHeader = """
-        |plugins {
-        |    id("kotlin-multiplatform")
-        |    id("com.codingfeline.buildkonfig")
-        |}
-        |
-        |repositories {
-        |   mavenCentral()
-        |}
-        |
-    """.trimMargin()
+    private val buildFileHeader = buildFileHeaderKts("kotlin-multiplatform")
 
     private val buildFileMPPConfig = """
         |kotlin {

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
@@ -17,17 +17,7 @@ class BuildKonfigPluginFlavorTest {
 
     lateinit var settingFile: File
 
-    private val buildFileHeader = """
-        |plugins {
-        |    id 'kotlin-multiplatform'
-        |    id 'com.codingfeline.buildkonfig'
-        |}
-        |
-        |repositories {
-        |   mavenCentral()
-        |}
-        |
-    """.trimMargin()
+    private val buildFileHeader = buildFileHeader("kotlin-multiplatform")
 
     private val buildFileMPPConfig = """
         |kotlin {

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginGradle9KspTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginGradle9KspTest.kt
@@ -23,18 +23,7 @@ class BuildKonfigPluginGradle9KspTest {
 
     lateinit var settingFile: File
 
-    private val buildFileHeader = """
-        |plugins {
-        |    id 'kotlin-multiplatform'
-        |    id 'com.google.devtools.ksp'
-        |    id 'com.codingfeline.buildkonfig'
-        |}
-        |
-        |repositories {
-        |   mavenCentral()
-        |}
-        |
-    """.trimMargin()
+    private val buildFileHeader = buildFileHeader("kotlin-multiplatform", "com.google.devtools.ksp")
 
     @Before
     fun setup() {

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginHMPPTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginHMPPTest.kt
@@ -17,17 +17,7 @@ class BuildKonfigPluginHMPPTest {
 
     lateinit var settingFile: File
 
-    private val buildFileHeader = """
-        |plugins {
-        |    id 'kotlin-multiplatform'
-        |    id 'com.codingfeline.buildkonfig'
-        |}
-        |
-        |repositories {
-        |   mavenCentral()
-        |}
-        |
-    """.trimMargin()
+    private val buildFileHeader = buildFileHeader("kotlin-multiplatform")
 
     @Before
     fun setup() {

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginKotlinDSLFlavorTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginKotlinDSLFlavorTest.kt
@@ -17,17 +17,7 @@ class BuildKonfigPluginKotlinDSLFlavorTest {
 
     lateinit var settingFile: File
 
-    private val buildFileHeader = """
-        |plugins {
-        |    id("kotlin-multiplatform")
-        |    id("com.codingfeline.buildkonfig")
-        |}
-        |
-        |repositories {
-        |   mavenCentral()
-        |}
-        |
-    """.trimMargin()
+    private val buildFileHeader = buildFileHeaderKts("kotlin-multiplatform")
 
     private val buildFileKMPConfig = """
         |kotlin {

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/TestUtils.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/TestUtils.kt
@@ -15,13 +15,33 @@ fun createAndroidManifest(projectDir: TemporaryFolder, sourceSetName: String = "
 
 
 /**
- * Build script header — `plugins { ... }` plus a `mavenCentral()` repository — for the given
- * Kotlin plugin id.
+ * Build script header — `plugins { ... }` plus a `mavenCentral()` repository — in Groovy
+ * DSL syntax (`build.gradle`). The Kotlin compiler plugin is applied first, then any
+ * [additionalPlugins] in order, then `com.codingfeline.buildkonfig` last.
  */
-fun buildFileHeader(kotlinPluginId: String): String = """
+fun buildFileHeader(kotlinPluginId: String, vararg additionalPlugins: String): String {
+    val pluginIds = listOf(kotlinPluginId) + additionalPlugins + "com.codingfeline.buildkonfig"
+    val pluginLines = pluginIds.joinToString("\n") { "            |    id '$it'" }
+    return """
             |plugins {
-            |    id '$kotlinPluginId'
-            |    id 'com.codingfeline.buildkonfig'
+$pluginLines
+            |}
+            |
+            |repositories {
+            |   mavenCentral()
+            |}
+            |
+        """.trimMargin()
+}
+
+/**
+ * Build script header — `plugins { ... }` plus a `mavenCentral()` repository — for the given
+ * Kotlin plugin id, in Kotlin DSL syntax (`build.gradle.kts`).
+ */
+fun buildFileHeaderKts(kotlinPluginId: String): String = """
+            |plugins {
+            |    id("$kotlinPluginId")
+            |    id("com.codingfeline.buildkonfig")
             |}
             |
             |repositories {


### PR DESCRIPTION
## Summary

Closes #297.

Replace the inline `private val buildFileHeader = \"\"\"...\"\"\"` block in the six remaining test files with a call to the existing `buildFileHeader(...)` helper from `TestUtils.kt`.

## What changed

- `TestUtils.kt`:
  - Extend `buildFileHeader` with a `vararg additionalPlugins: String` parameter so the KSP test can declare `buildFileHeader(\"kotlin-multiplatform\", \"com.google.devtools.ksp\")`. Existing one-arg callers are unaffected.
  - Add `buildFileHeaderKts(kotlinPluginId)` for tests that target `build.gradle.kts` (Kotlin DSL syntax: `id(\"...\")`).
- Migrate the inline header block in:
  - `BuildKonfigPluginConfigurationCacheTest.kt` → `buildFileHeader(\"kotlin-multiplatform\")`
  - `BuildKonfigPluginFlavorTest.kt` → `buildFileHeader(\"kotlin-multiplatform\")`
  - `BuildKonfigPluginGradle9KspTest.kt` → `buildFileHeader(\"kotlin-multiplatform\", \"com.google.devtools.ksp\")`
  - `BuildKonfigPluginHMPPTest.kt` → `buildFileHeader(\"kotlin-multiplatform\")`
  - `BuildKonfigPluginConstFieldsTest.kt` → `buildFileHeaderKts(\"kotlin-multiplatform\")`
  - `BuildKonfigPluginKotlinDSLFlavorTest.kt` → `buildFileHeaderKts(\"kotlin-multiplatform\")`

`BuildkonfigPluginKotlinDSLTest.kt` is intentionally left alone (it inlines the plugins block per test, no `buildFileHeader` constant exists there).

## Test plan

- [x] `./gradlew :buildkonfig-gradle-plugin:test` — all tests pass. Verbatim string output of each helper call matches the previous inline block, so existing test assertions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)