### PR TITLE
refactor: align internal naming with the "KMP" abbreviation

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ buildkonfig {
 <summary>Groovy DSL</summary>
 
 ```gradle
-// ./mpp_project/build.gradle
+// ./kmp_project/build.gradle
 
 buildkonfig {
     packageName = 'com.example.app'

--- a/buildkonfig-gradle-plugin/gradle.properties
+++ b/buildkonfig-gradle-plugin/gradle.properties
@@ -1,4 +1,4 @@
 POM_ARTIFACT_ID=buildkonfig-gradle-plugin
 POM_NAME=BuildKonfig Gradle Plugin
-POM_DESCRIPTION=Gradle plugin to generate BuildConfig object for Kotlin MPP
+POM_DESCRIPTION=Gradle plugin to generate BuildConfig object for Kotlin Multiplatform
 POM_PACKAGING=jar

--- a/buildkonfig-gradle-plugin/gradle.properties
+++ b/buildkonfig-gradle-plugin/gradle.properties
@@ -1,4 +1,4 @@
 POM_ARTIFACT_ID=buildkonfig-gradle-plugin
 POM_NAME=BuildKonfig Gradle Plugin
-POM_DESCRIPTION=Gradle plugin to generate BuildConfig object for Kotlin Multiplatform
+POM_DESCRIPTION=Gradle plugin to generate BuildConfig object for Kotlin Multiplatform, Kotlin/JVM, and Kotlin/JS projects
 POM_PACKAGING=jar

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -79,9 +79,9 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         // or a single-target Kotlin project. Both code paths run in afterEvaluate so the
         // user's DSL block and any KMP target registrations have already completed.
         project.afterEvaluate {
-            val mppExtension = project.extensions.findByType(KotlinMultiplatformExtension::class.java)
-            if (mppExtension != null) {
-                configureMultiplatform(project, extension, task, mppExtension)
+            val kmpExtension = project.extensions.findByType(KotlinMultiplatformExtension::class.java)
+            if (kmpExtension != null) {
+                configureMultiplatform(project, extension, task, kmpExtension)
             } else {
                 configureSinglePlatform(project, extension, task)
             }
@@ -92,7 +92,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         project: Project,
         extension: BuildKonfigExtension,
         task: TaskProvider<BuildKonfigTask>,
-        mppExtension: KotlinMultiplatformExtension,
+        kmpExtension: KotlinMultiplatformExtension,
     ) {
         val outputDirectory = project.layout.buildDirectory.dir("buildkonfig")
 
@@ -105,12 +105,12 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
 
         // When both js and wasm targets exist with exposeObject, force expect/actual generation
         // so that @JsExport is only added to the JS actual (wasmJs doesn't support @JsExport on objects).
-        val hasJsTarget = mppExtension.targets.any { t -> t.platformType == KotlinPlatformType.js }
-        val hasWasmTarget = mppExtension.targets.any { t -> t.platformType == KotlinPlatformType.wasm }
+        val hasJsTarget = kmpExtension.targets.any { t -> t.platformType == KotlinPlatformType.js }
+        val hasWasmTarget = kmpExtension.targets.any { t -> t.platformType == KotlinPlatformType.wasm }
         val forceExpectActual = exposeObject && hasJsTarget && hasWasmTarget
 
         val targetConfigSources =
-            decideOutputs(project, mppExtension, mergedConfigs, outputDirectory, forceExpectActual)
+            decideOutputs(project, kmpExtension, mergedConfigs, outputDirectory, forceExpectActual)
 
         task.configure { t ->
             t.flavor.set(flavor)
@@ -184,12 +184,12 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
 
 fun decideOutputs(
     project: Project,
-    mppExtension: KotlinMultiplatformExtension,
+    kmpExtension: KotlinMultiplatformExtension,
     targetConfigs: Map<String, TargetConfig>,
     outputDirectory: Provider<Directory>,
     forceExpectActual: Boolean = false
 ): Map<String, TargetConfigSource> {
-    return mppExtension.sources()
+    return kmpExtension.sources()
         // Map<SourceName, TargetConfigSource>
         .fold(emptyMap()) { acc, source ->
             if (targetConfigs.size == 1 && source.name != COMMON_SOURCESET_NAME && !forceExpectActual) {

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConfigurationCacheTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConfigurationCacheTest.kt
@@ -19,7 +19,7 @@ class BuildKonfigPluginConfigurationCacheTest {
 
     private val buildFileHeader = buildFileHeader("kotlin-multiplatform")
 
-    private val buildFileMPPConfig = """
+    private val buildFileKMPConfig = """
         |kotlin {
         |  jvm()
         |  iosX64()
@@ -63,7 +63,7 @@ class BuildKonfigPluginConfigurationCacheTest {
             |   }
             |}
             |
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
             """.trimMargin()
         )
 

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
@@ -19,7 +19,7 @@ class BuildKonfigPluginConstFieldsTest {
 
     private val buildFileHeader = buildFileHeaderKts("kotlin-multiplatform")
 
-    private val buildFileMPPConfig = """
+    private val buildFileKMPConfig = """
         |kotlin {
         |  jvm()
         |  js(IR) {
@@ -58,7 +58,7 @@ class BuildKonfigPluginConstFieldsTest {
             |   }
             |}
             |
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
             """.trimMargin()
         )
 

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
@@ -19,7 +19,7 @@ class BuildKonfigPluginFlavorTest {
 
     private val buildFileHeader = buildFileHeader("kotlin-multiplatform")
 
-    private val buildFileMPPConfig = """
+    private val buildFileKMPConfig = """
         |kotlin {
         |  jvm()
         |  js(IR) {
@@ -50,7 +50,7 @@ class BuildKonfigPluginFlavorTest {
             |       buildConfigField 'STRING', 'stringValue', 'defaultValue'
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -109,7 +109,7 @@ class BuildKonfigPluginFlavorTest {
             |       buildConfigField 'STRING', 'stringValue', 'devDefaultValue'
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -163,7 +163,7 @@ class BuildKonfigPluginFlavorTest {
             |       buildConfigField 'STRING', 'stringValue', 'releaseDefaultValue'
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -219,7 +219,7 @@ class BuildKonfigPluginFlavorTest {
             |       }
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -274,7 +274,7 @@ class BuildKonfigPluginFlavorTest {
             |       }
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -322,7 +322,7 @@ class BuildKonfigPluginFlavorTest {
             |       buildConfigField 'INT', 'intValue', '10', nullable: true
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -364,7 +364,7 @@ class BuildKonfigPluginFlavorTest {
             |       buildConfigNullableField 'INT', 'intValue', null
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -415,7 +415,7 @@ class BuildKonfigPluginFlavorTest {
             |       }
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -472,7 +472,7 @@ class BuildKonfigPluginFlavorTest {
             |       }
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -520,7 +520,7 @@ class BuildKonfigPluginFlavorTest {
             |       buildConfigField 'STRING', 'stringValue', 'defaultValue'
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -566,7 +566,7 @@ class BuildKonfigPluginFlavorTest {
             |       }
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -619,7 +619,7 @@ class BuildKonfigPluginFlavorTest {
             |       buildConfigField 'STRING', 'stringValue', 'defaultValue'
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -667,7 +667,7 @@ class BuildKonfigPluginFlavorTest {
             |       }
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 
@@ -710,7 +710,7 @@ class BuildKonfigPluginFlavorTest {
             .contains("object AwesomeConfig")
     }
 
-    private val buildFileMPPConfigWithWasmJs = """
+    private val buildFileKMPConfigWithWasmJs = """
         |kotlin {
         |  jvm()
         |  js(IR) {
@@ -724,7 +724,7 @@ class BuildKonfigPluginFlavorTest {
         |}
     """.trimMargin()
 
-    private val buildFileMPPConfigWasmJsOnly = """
+    private val buildFileKMPConfigWasmJsOnly = """
         |kotlin {
         |  jvm()
         |  wasmJs {
@@ -748,7 +748,7 @@ class BuildKonfigPluginFlavorTest {
             |       buildConfigField 'STRING', 'stringValue', 'defaultValue'
             |   }
             |}
-            |$buildFileMPPConfigWithWasmJs
+            |$buildFileKMPConfigWithWasmJs
         """.trimMargin()
         )
 
@@ -807,7 +807,7 @@ class BuildKonfigPluginFlavorTest {
             |       buildConfigField 'STRING', 'stringValue', 'defaultValue'
             |   }
             |}
-            |$buildFileMPPConfigWasmJsOnly
+            |$buildFileKMPConfigWasmJsOnly
         """.trimMargin()
         )
 
@@ -855,7 +855,7 @@ class BuildKonfigPluginFlavorTest {
             |       }
             |   }
             |}
-            |$buildFileMPPConfigWithWasmJs
+            |$buildFileKMPConfigWithWasmJs
         """.trimMargin()
         )
 
@@ -910,7 +910,7 @@ class BuildKonfigPluginFlavorTest {
             |       buildConfigField 'STRING', 'stringValue', 'releaseDefaultValue'
             |   }
             |}
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
         """.trimMargin()
         )
 

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
@@ -19,7 +19,7 @@ class BuildKonfigPluginTest {
 
     private val buildFileHeader = buildFileHeader("kotlin-multiplatform")
 
-    private val buildFileMPPConfig = """
+    private val buildFileKMPConfig = """
         |kotlin {
         |  jvm()
         |  js {
@@ -161,7 +161,7 @@ class BuildKonfigPluginTest {
             |   }
             |}
             |
-            |$buildFileMPPConfig
+            |$buildFileKMPConfig
             """.trimMargin()
         )
 


### PR DESCRIPTION
## Summary

- Rename leftover `MPP` usages in code and docs to `KMP`. JetBrains has been promoting `KMP` as the preferred shorthand for Kotlin Multiplatform since [2023](https://blog.jetbrains.com/kotlin/2023/07/update-on-the-name-of-kotlin-multiplatform/); `MPP` was the older community shorthand.
- `BuildKonfigPlugin`: local/parameter name `mppExtension` → `kmpExtension`
- Test fixtures: `buildFileMPPConfig` (incl. Wasm/Js variants) → `buildFileKMPConfig`
- `README.md`: example path comment `./mpp_project/build.gradle` → `./kmp_project/build.gradle`
- `gradle.properties`: broaden POM description to mention Kotlin Multiplatform, Kotlin/JVM, and Kotlin/JS — the previous wording predated #296, which added standalone JVM/JS support.

## What is intentionally NOT changed

- `org.jetbrains.kotlin.gradle.plugin.mpp.*` imports — actual KGP package names
- `kotlin.mpp.androidSourceSetLayoutVersion` — Kotlin Gradle property name
- `HMPP` references in `CHANGELOG.md`, `README.md`, `AGENTS.md`, and the `BuildKonfigPluginHMPPTest` class — `HMPP` is a distinct historical term (Hierarchical Multi-Platform Project) and renaming it would break recognized terminology and existing anchors
- The `kotlinlang.org/docs/mpp-share-on-platforms.html` link — external URL outside our control

No behavior changes; this is purely a naming / metadata refactor.

## Test plan

- [x] `./gradlew :buildkonfig-gradle-plugin:test` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)