### PR TITLE
refactor(test): reduce boilerplate in the Gradle plugin test suite

### DIFF
--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BaseGradlePluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BaseGradlePluginTest.kt
@@ -1,0 +1,40 @@
+package com.codingfeline.buildkonfig.gradle
+
+import org.junit.Before
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Common scaffolding for Gradle TestKit-driven tests.
+ *
+ * Provides a per-test [TemporaryFolder], creates an empty build script and a
+ * `settings.gradle` populated with [settingsGradle], and exposes [extraSetup] for
+ * subclass-specific files such as `gradle.properties` or source fixtures.
+ */
+abstract class BaseGradlePluginTest {
+
+    @get:Rule
+    val projectDir = TemporaryFolder()
+
+    lateinit var buildFile: File
+
+    lateinit var settingFile: File
+
+    /** Override to use `build.gradle.kts` instead of the default `build.gradle`. */
+    protected open val buildFileName: String = "build.gradle"
+
+    @Before
+    fun baseSetup() {
+        buildFile = projectDir.newFile(buildFileName)
+        settingFile = projectDir.newFile("settings.gradle")
+        settingFile.writeText(settingsGradle)
+        extraSetup()
+    }
+
+    /**
+     * Hook for subclasses to write additional files (e.g. `gradle.properties`,
+     * Kotlin source fixtures) after the standard setup has run.
+     */
+    protected open fun extraSetup() {}
+}

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BaseGradlePluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BaseGradlePluginTest.kt
@@ -17,9 +17,9 @@ abstract class BaseGradlePluginTest {
     @get:Rule
     val projectDir = TemporaryFolder()
 
-    lateinit var buildFile: File
+    protected lateinit var buildFile: File
 
-    lateinit var settingFile: File
+    protected lateinit var settingFile: File
 
     /** Override to use `build.gradle.kts` instead of the default `build.gradle`. */
     protected open val buildFileName: String = "build.gradle"

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConfigurationCacheTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConfigurationCacheTest.kt
@@ -1,21 +1,9 @@
 package com.codingfeline.buildkonfig.gradle
 
 import com.google.common.truth.Truth.assertThat
-import org.gradle.testkit.runner.GradleRunner
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import java.io.File
 
-class BuildKonfigPluginConfigurationCacheTest {
-
-    @get:Rule
-    val projectDir = TemporaryFolder()
-
-    lateinit var buildFile: File
-
-    lateinit var settingFile: File
+class BuildKonfigPluginConfigurationCacheTest : BaseGradlePluginTest() {
 
     private val buildFileHeader = buildFileHeader("kotlin-multiplatform")
 
@@ -34,13 +22,6 @@ class BuildKonfigPluginConfigurationCacheTest {
         |  }
         |}
     """.trimMargin()
-
-    @Before
-    fun setup() {
-        buildFile = projectDir.newFile("build.gradle")
-        settingFile = projectDir.newFile("settings.gradle")
-        settingFile.writeText(settingsGradle)
-    }
 
     @Test
     fun `generateBuildKonfig is compatible with Configuration Cache`() {
@@ -67,9 +48,7 @@ class BuildKonfigPluginConfigurationCacheTest {
             """.trimMargin()
         )
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
+        val runner = gradleRunner(projectDir)
 
         // First run: store the configuration cache entry.
         val firstRun = runner

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
@@ -1,21 +1,11 @@
 package com.codingfeline.buildkonfig.gradle
 
 import com.google.common.truth.Truth
-import org.gradle.testkit.runner.GradleRunner
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import java.io.File
 
-class BuildKonfigPluginConstFieldsTest {
+class BuildKonfigPluginConstFieldsTest : BaseGradlePluginTest() {
 
-    @get:Rule
-    val projectDir = TemporaryFolder()
-
-    lateinit var buildFile: File
-
-    lateinit var settingFile: File
+    override val buildFileName: String = "build.gradle.kts"
 
     private val buildFileHeader = buildFileHeaderKts("kotlin-multiplatform")
 
@@ -29,13 +19,6 @@ class BuildKonfigPluginConstFieldsTest {
         |}
     """.trimMargin()
 
-    @Before
-    fun setup() {
-        buildFile = projectDir.newFile("build.gradle.kts")
-        settingFile = projectDir.newFile("settings.gradle")
-        settingFile.writeText(settingsGradle)
-    }
-
     @Test
     fun `const values produce expect val on common and actual const val on targets`() {
         buildFile.writeText(
@@ -45,7 +28,7 @@ class BuildKonfigPluginConstFieldsTest {
             |
             |buildkonfig {
             |   packageName = "com.example"
-            |   
+            |
             |   defaultConfigs {
             |       buildConfigConstField(Type.STRING, "foo", "defaultValue")
             |       buildConfigField(type = Type.STRING, name = "bar", value = "defaultBarValue", const = true)
@@ -62,19 +45,12 @@ class BuildKonfigPluginConstFieldsTest {
             """.trimMargin()
         )
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        val result = gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace", "--warning-mode=all")
             .build()
-
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
+            .assertBuildSuccessful()
 
         Truth.assertThat(result.output).apply {
             contains("declared with `const = true` but target-specific configs are present")
@@ -82,7 +58,7 @@ class BuildKonfigPluginConstFieldsTest {
             contains("bar")
         }
 
-        val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example")
         Truth.assertThat(commonResult.readText()).apply {
             contains("public val foo: String")
             contains("public val bar: String")
@@ -91,13 +67,13 @@ class BuildKonfigPluginConstFieldsTest {
             doesNotContain("CONST_VAL_WITHOUT_INITIALIZER")
         }
 
-        val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
+        val jvmResult = buildKonfigFile(buildDir, "jvmMain", "com.example")
         Truth.assertThat(jvmResult.readText()).apply {
             contains("actual const val foo: String = \"defaultValue\"")
             contains("actual const val bar: String = \"defaultBarValue\"")
         }
 
-        val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
+        val jsResult = buildKonfigFile(buildDir, "jsMain", "com.example")
         Truth.assertThat(jsResult.readText()).apply {
             contains("actual const val foo: String = \"jsValue\"")
             contains("actual const val bar: String = \"jsBarValue\"")

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConstFieldsTest.kt
@@ -1,6 +1,6 @@
 package com.codingfeline.buildkonfig.gradle
 
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class BuildKonfigPluginConstFieldsTest : BaseGradlePluginTest() {
@@ -52,14 +52,14 @@ class BuildKonfigPluginConstFieldsTest : BaseGradlePluginTest() {
             .build()
             .assertBuildSuccessful()
 
-        Truth.assertThat(result.output).apply {
+        assertThat(result.output).apply {
             contains("declared with `const = true` but target-specific configs are present")
             contains("foo")
             contains("bar")
         }
 
         val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example")
-        Truth.assertThat(commonResult.readText()).apply {
+        assertThat(commonResult.readText()).apply {
             contains("public val foo: String")
             contains("public val bar: String")
             doesNotContain("const val foo")
@@ -68,13 +68,13 @@ class BuildKonfigPluginConstFieldsTest : BaseGradlePluginTest() {
         }
 
         val jvmResult = buildKonfigFile(buildDir, "jvmMain", "com.example")
-        Truth.assertThat(jvmResult.readText()).apply {
+        assertThat(jvmResult.readText()).apply {
             contains("actual const val foo: String = \"defaultValue\"")
             contains("actual const val bar: String = \"defaultBarValue\"")
         }
 
         val jsResult = buildKonfigFile(buildDir, "jsMain", "com.example")
-        Truth.assertThat(jsResult.readText()).apply {
+        assertThat(jsResult.readText()).apply {
             contains("actual const val foo: String = \"jsValue\"")
             contains("actual const val bar: String = \"jsBarValue\"")
         }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
@@ -1,6 +1,6 @@
 package com.codingfeline.buildkonfig.gradle
 
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
@@ -71,7 +71,7 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example")
-        Truth.assertThat(commonResult.readText())
+        assertThat(commonResult.readText())
             .isEqualTo(
                 """
                 |package com.example
@@ -85,9 +85,9 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             """.trimMargin()
             )
 
-        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").exists()).isFalse()
     }
 
     @Test
@@ -120,12 +120,12 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example")
-        Truth.assertThat(commonResult.readText())
+        assertThat(commonResult.readText())
             .contains("val stringValue: String = \"devDefaultValue\"")
 
-        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").exists()).isFalse()
     }
 
     @Test
@@ -161,12 +161,12 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example")
-        Truth.assertThat(commonResult.readText())
+        assertThat(commonResult.readText())
             .contains("val stringValue: String = \"releaseDefaultValue\"")
 
-        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").exists()).isFalse()
     }
 
     @Test
@@ -203,11 +203,11 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .build()
             .assertBuildSuccessful()
 
-        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").readText())
+        assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").readText())
             .contains("jvmDefaultValue")
-        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").readText())
+        assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").readText())
             .contains("devDefaultValue")
-        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").readText())
+        assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").readText())
             .contains("devDefaultValue")
     }
 
@@ -245,11 +245,11 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .build()
             .assertBuildSuccessful()
 
-        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").readText())
+        assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").readText())
             .contains("devDefaultValue")
-        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").readText())
+        assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").readText())
             .contains("devJsValue")
-        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").readText())
+        assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").readText())
             .contains("devDefaultValue")
     }
 
@@ -281,7 +281,7 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example")
-        Truth.assertThat(commonResult.readText()).apply {
+        assertThat(commonResult.readText()).apply {
             contains("stringValue: String? = \"defaultValue\"")
             contains("intValue: Int? = 10")
         }
@@ -315,7 +315,7 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example")
-        Truth.assertThat(commonResult.readText()).apply {
+        assertThat(commonResult.readText()).apply {
             contains("stringValue: String? = null")
             contains("intValue: Int? = null")
         }
@@ -357,11 +357,11 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .build()
             .assertBuildSuccessful()
 
-        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").readText())
+        assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").readText())
             .contains("defaultValue")
-        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").readText())
+        assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").readText())
             .contains("devJsValue")
-        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").readText())
+        assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").readText())
             .contains("defaultValue")
     }
 
@@ -401,11 +401,11 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .build()
             .assertBuildSuccessful()
 
-        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").readText())
+        assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").readText())
             .contains("defaultValue")
-        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").readText())
+        assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").readText())
             .contains("defaultJsValue")
-        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").readText())
+        assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").readText())
             .contains("defaultValue")
     }
 
@@ -437,7 +437,7 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example", objectName = "AwesomeConfig")
-        Truth.assertThat(commonResult.readText()).apply {
+        assertThat(commonResult.readText()).apply {
             contains("internal object AwesomeConfig")
         }
     }
@@ -475,15 +475,15 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example", objectName = "AwesomeConfig")
-        Truth.assertThat(commonResult.readText()).apply {
+        assertThat(commonResult.readText()).apply {
             contains("internal expect object AwesomeConfig")
         }
 
-        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example", objectName = "AwesomeConfig").readText())
+        assertThat(buildKonfigFile(buildDir, "jsMain", "com.example", objectName = "AwesomeConfig").readText())
             .contains("internal actual object AwesomeConfig")
-        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example", objectName = "AwesomeConfig").readText())
+        assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example", objectName = "AwesomeConfig").readText())
             .contains("internal actual object AwesomeConfig")
-        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example", objectName = "AwesomeConfig").readText())
+        assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example", objectName = "AwesomeConfig").readText())
             .contains("internal actual object AwesomeConfig")
     }
 
@@ -515,7 +515,7 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example", objectName = "AwesomeConfig")
-        Truth.assertThat(commonResult.readText()).apply {
+        assertThat(commonResult.readText()).apply {
             contains("@JsExport")
             contains("@OptIn(ExperimentalJsExport::class)")
             contains("object AwesomeConfig")
@@ -555,20 +555,20 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example", objectName = "AwesomeConfig")
-        Truth.assertThat(commonResult.readText()).apply {
+        assertThat(commonResult.readText()).apply {
             contains("object AwesomeConfig")
         }
 
         val jsResult = buildKonfigFile(buildDir, "jsMain", "com.example", objectName = "AwesomeConfig")
-        Truth.assertThat(jsResult.readText()).apply {
+        assertThat(jsResult.readText()).apply {
             contains("@JsExport")
             contains("@OptIn(ExperimentalJsExport::class)")
             contains("object AwesomeConfig")
         }
 
-        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example", objectName = "AwesomeConfig").readText())
+        assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example", objectName = "AwesomeConfig").readText())
             .contains("object AwesomeConfig")
-        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example", objectName = "AwesomeConfig").readText())
+        assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example", objectName = "AwesomeConfig").readText())
             .contains("object AwesomeConfig")
     }
 
@@ -601,14 +601,14 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
 
         // common should be expect (no @JsExport)
         val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example", objectName = "AwesomeConfig")
-        Truth.assertThat(commonResult.readText()).apply {
+        assertThat(commonResult.readText()).apply {
             doesNotContain("@JsExport")
             contains("expect object AwesomeConfig")
         }
 
         // js actual should have @JsExport
         val jsResult = buildKonfigFile(buildDir, "jsMain", "com.example", objectName = "AwesomeConfig")
-        Truth.assertThat(jsResult.readText()).apply {
+        assertThat(jsResult.readText()).apply {
             contains("@JsExport")
             contains("@OptIn(ExperimentalJsExport::class)")
             contains("actual object AwesomeConfig")
@@ -616,7 +616,7 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
 
         // wasmJs actual should NOT have @JsExport
         val wasmJsResult = buildKonfigFile(buildDir, "wasmJsMain", "com.example", objectName = "AwesomeConfig")
-        Truth.assertThat(wasmJsResult.readText()).apply {
+        assertThat(wasmJsResult.readText()).apply {
             doesNotContain("@JsExport")
             doesNotContain("@OptIn(ExperimentalJsExport::class)")
             contains("actual object AwesomeConfig")
@@ -651,7 +651,7 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example", objectName = "AwesomeConfig")
-        Truth.assertThat(commonResult.readText()).apply {
+        assertThat(commonResult.readText()).apply {
             doesNotContain("@JsExport")
             doesNotContain("@OptIn(ExperimentalJsExport::class)")
             contains("object AwesomeConfig")
@@ -691,14 +691,14 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val jsResult = buildKonfigFile(buildDir, "jsMain", "com.example", objectName = "AwesomeConfig")
-        Truth.assertThat(jsResult.readText()).apply {
+        assertThat(jsResult.readText()).apply {
             contains("@JsExport")
             contains("@OptIn(ExperimentalJsExport::class)")
             contains("object AwesomeConfig")
         }
 
         val wasmJsResult = buildKonfigFile(buildDir, "wasmJsMain", "com.example", objectName = "AwesomeConfig")
-        Truth.assertThat(wasmJsResult.readText()).apply {
+        assertThat(wasmJsResult.readText()).apply {
             doesNotContain("@JsExport")
             doesNotContain("@OptIn(ExperimentalJsExport::class)")
             contains("object AwesomeConfig")
@@ -738,7 +738,7 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .build()
             .assertBuildSuccessful()
         val devCommon = buildKonfigFile(buildDir, "commonMain", "com.example")
-        Truth.assertThat(devCommon.readText())
+        assertThat(devCommon.readText())
             .contains("val stringValue: String = \"devDefaultValue\"")
 
         // Second build with flavor=release should NOT be UP-TO-DATE and must regenerate.
@@ -747,10 +747,10 @@ class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
             .build()
             .assertBuildSuccessful()
 
-        Truth.assertThat(releaseResult.output).doesNotContain("generateBuildKonfig UP-TO-DATE")
+        assertThat(releaseResult.output).doesNotContain("generateBuildKonfig UP-TO-DATE")
 
         val releaseCommon = buildKonfigFile(buildDir, "commonMain", "com.example")
-        Truth.assertThat(releaseCommon.readText())
+        assertThat(releaseCommon.readText())
             .contains("val stringValue: String = \"releaseDefaultValue\"")
     }
 }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginFlavorTest.kt
@@ -1,21 +1,9 @@
 package com.codingfeline.buildkonfig.gradle
 
 import com.google.common.truth.Truth
-import org.gradle.testkit.runner.GradleRunner
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import java.io.File
 
-class BuildKonfigPluginFlavorTest {
-
-    @get:Rule
-    val projectDir = TemporaryFolder()
-
-    lateinit var buildFile: File
-
-    lateinit var settingFile: File
+class BuildKonfigPluginFlavorTest : BaseGradlePluginTest() {
 
     private val buildFileHeader = buildFileHeader("kotlin-multiplatform")
 
@@ -30,11 +18,32 @@ class BuildKonfigPluginFlavorTest {
         |}
     """.trimMargin()
 
-    @Before
-    fun setup() {
-        buildFile = projectDir.newFile("build.gradle")
-        settingFile = projectDir.newFile("settings.gradle")
-        settingFile.writeText(settingsGradle)
+    private val buildFileKMPConfigWithWasmJs = """
+        |kotlin {
+        |  jvm()
+        |  js(IR) {
+        |    browser()
+        |    nodejs()
+        |  }
+        |  wasmJs {
+        |    browser()
+        |  }
+        |  iosX64()
+        |}
+    """.trimMargin()
+
+    private val buildFileKMPConfigWasmJsOnly = """
+        |kotlin {
+        |  jvm()
+        |  wasmJs {
+        |    browser()
+        |  }
+        |  iosX64()
+        |}
+    """.trimMargin()
+
+    private fun writeFlavorDevProperties() {
+        projectDir.newFile("gradle.properties").writeText("buildkonfig.flavor=dev")
     }
 
     @Test
@@ -54,21 +63,14 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example")
         Truth.assertThat(commonResult.readText())
             .isEqualTo(
                 """
@@ -83,14 +85,9 @@ class BuildKonfigPluginFlavorTest {
             """.trimMargin()
             )
 
-        val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jvmResult.exists()).isFalse()
-
-        val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jsResult.exists()).isFalse()
-
-        val iosResult = File(buildDir, "iosX64Main/com/example/BuildKonfig.kt")
-        Truth.assertThat(iosResult.exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").exists()).isFalse()
     }
 
     @Test
@@ -113,35 +110,22 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example")
         Truth.assertThat(commonResult.readText())
             .contains("val stringValue: String = \"devDefaultValue\"")
 
-        val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jvmResult.exists()).isFalse()
-
-        val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jsResult.exists()).isFalse()
-
-        val iosResult = File(buildDir, "iosX64Main/com/example/BuildKonfig.kt")
-        Truth.assertThat(iosResult.exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").exists()).isFalse()
     }
 
     @Test
@@ -167,35 +151,22 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace", "-Pbuildkonfig.flavor=release")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example")
         Truth.assertThat(commonResult.readText())
             .contains("val stringValue: String = \"releaseDefaultValue\"")
 
-        val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jvmResult.exists()).isFalse()
-
-        val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jsResult.exists()).isFalse()
-
-        val iosResult = File(buildDir, "iosX64Main/com/example/BuildKonfig.kt")
-        Truth.assertThat(iosResult.exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").exists()).isFalse()
     }
 
     @Test
@@ -223,33 +194,20 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jvmResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").readText())
             .contains("jvmDefaultValue")
-
-        val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jsResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").readText())
             .contains("devDefaultValue")
-
-        val iosResult = File(buildDir, "iosX64Main/com/example/BuildKonfig.kt")
-        Truth.assertThat(iosResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").readText())
             .contains("devDefaultValue")
     }
 
@@ -278,33 +236,20 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jvmResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").readText())
             .contains("devDefaultValue")
-
-        val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jsResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").readText())
             .contains("devJsValue")
-
-        val iosResult = File(buildDir, "iosX64Main/com/example/BuildKonfig.kt")
-        Truth.assertThat(iosResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").readText())
             .contains("devDefaultValue")
     }
 
@@ -326,24 +271,16 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example")
         Truth.assertThat(commonResult.readText()).apply {
             contains("stringValue: String? = \"defaultValue\"")
             contains("intValue: Int? = 10")
@@ -368,24 +305,16 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val commonResult = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example")
         Truth.assertThat(commonResult.readText()).apply {
             contains("stringValue: String? = null")
             contains("intValue: Int? = null")
@@ -419,33 +348,20 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jvmResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").readText())
             .contains("defaultValue")
-
-        val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jsResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").readText())
             .contains("devJsValue")
-
-        val iosResult = File(buildDir, "iosX64Main/com/example/BuildKonfig.kt")
-        Truth.assertThat(iosResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").readText())
             .contains("defaultValue")
     }
 
@@ -476,33 +392,20 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace", "-Pbuildkonfig.flavor=nonexistent")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jvmResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example").readText())
             .contains("defaultValue")
-
-        val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
-        Truth.assertThat(jsResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example").readText())
             .contains("defaultJsValue")
-
-        val iosResult = File(buildDir, "iosX64Main/com/example/BuildKonfig.kt")
-        Truth.assertThat(iosResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example").readText())
             .contains("defaultValue")
     }
 
@@ -524,24 +427,16 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val commonResult = File(buildDir, "commonMain/com/example/AwesomeConfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example", objectName = "AwesomeConfig")
         Truth.assertThat(commonResult.readText()).apply {
             contains("internal object AwesomeConfig")
         }
@@ -570,38 +465,25 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val commonResult = File(buildDir, "commonMain/com/example/AwesomeConfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example", objectName = "AwesomeConfig")
         Truth.assertThat(commonResult.readText()).apply {
             contains("internal expect object AwesomeConfig")
         }
 
-        val jsResult = File(buildDir, "jsMain/com/example/AwesomeConfig.kt")
-        Truth.assertThat(jsResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "jsMain", "com.example", objectName = "AwesomeConfig").readText())
             .contains("internal actual object AwesomeConfig")
-
-        val jvmResult = File(buildDir, "jvmMain/com/example/AwesomeConfig.kt")
-        Truth.assertThat(jvmResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example", objectName = "AwesomeConfig").readText())
             .contains("internal actual object AwesomeConfig")
-
-        val iosResult = File(buildDir, "iosX64Main/com/example/AwesomeConfig.kt")
-        Truth.assertThat(iosResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example", objectName = "AwesomeConfig").readText())
             .contains("internal actual object AwesomeConfig")
     }
 
@@ -623,24 +505,16 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val commonResult = File(buildDir, "commonMain/com/example/AwesomeConfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example", objectName = "AwesomeConfig")
         Truth.assertThat(commonResult.readText()).apply {
             contains("@JsExport")
             contains("@OptIn(ExperimentalJsExport::class)")
@@ -671,68 +545,32 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val commonResult = File(buildDir, "commonMain/com/example/AwesomeConfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example", objectName = "AwesomeConfig")
         Truth.assertThat(commonResult.readText()).apply {
             contains("object AwesomeConfig")
         }
 
-        val jsResult = File(buildDir, "jsMain/com/example/AwesomeConfig.kt")
-
+        val jsResult = buildKonfigFile(buildDir, "jsMain", "com.example", objectName = "AwesomeConfig")
         Truth.assertThat(jsResult.readText()).apply {
             contains("@JsExport")
             contains("@OptIn(ExperimentalJsExport::class)")
             contains("object AwesomeConfig")
         }
 
-        val jvmResult = File(buildDir, "jvmMain/com/example/AwesomeConfig.kt")
-        Truth.assertThat(jvmResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.example", objectName = "AwesomeConfig").readText())
             .contains("object AwesomeConfig")
-
-        val iosResult = File(buildDir, "iosX64Main/com/example/AwesomeConfig.kt")
-        Truth.assertThat(iosResult.readText())
+        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.example", objectName = "AwesomeConfig").readText())
             .contains("object AwesomeConfig")
     }
-
-    private val buildFileKMPConfigWithWasmJs = """
-        |kotlin {
-        |  jvm()
-        |  js(IR) {
-        |    browser()
-        |    nodejs()
-        |  }
-        |  wasmJs {
-        |    browser()
-        |  }
-        |  iosX64()
-        |}
-    """.trimMargin()
-
-    private val buildFileKMPConfigWasmJsOnly = """
-        |kotlin {
-        |  jvm()
-        |  wasmJs {
-        |    browser()
-        |  }
-        |  iosX64()
-        |}
-    """.trimMargin()
 
     @Test
     fun `When both js and wasmJs targets exist, expect actual is forced and JsExport is only on js actual`() {
@@ -752,32 +590,24 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
-
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
+            .assertBuildSuccessful()
 
         // common should be expect (no @JsExport)
-        val commonResult = File(buildDir, "commonMain/com/example/AwesomeConfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example", objectName = "AwesomeConfig")
         Truth.assertThat(commonResult.readText()).apply {
             doesNotContain("@JsExport")
             contains("expect object AwesomeConfig")
         }
 
         // js actual should have @JsExport
-        val jsResult = File(buildDir, "jsMain/com/example/AwesomeConfig.kt")
+        val jsResult = buildKonfigFile(buildDir, "jsMain", "com.example", objectName = "AwesomeConfig")
         Truth.assertThat(jsResult.readText()).apply {
             contains("@JsExport")
             contains("@OptIn(ExperimentalJsExport::class)")
@@ -785,7 +615,7 @@ class BuildKonfigPluginFlavorTest {
         }
 
         // wasmJs actual should NOT have @JsExport
-        val wasmJsResult = File(buildDir, "wasmJsMain/com/example/AwesomeConfig.kt")
+        val wasmJsResult = buildKonfigFile(buildDir, "wasmJsMain", "com.example", objectName = "AwesomeConfig")
         Truth.assertThat(wasmJsResult.readText()).apply {
             doesNotContain("@JsExport")
             doesNotContain("@OptIn(ExperimentalJsExport::class)")
@@ -811,24 +641,16 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val commonResult = File(buildDir, "commonMain/com/example/AwesomeConfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.example", objectName = "AwesomeConfig")
         Truth.assertThat(commonResult.readText()).apply {
             doesNotContain("@JsExport")
             doesNotContain("@OptIn(ExperimentalJsExport::class)")
@@ -859,31 +681,23 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        writeFlavorDevProperties()
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val jsResult = File(buildDir, "jsMain/com/example/AwesomeConfig.kt")
+        val jsResult = buildKonfigFile(buildDir, "jsMain", "com.example", objectName = "AwesomeConfig")
         Truth.assertThat(jsResult.readText()).apply {
             contains("@JsExport")
             contains("@OptIn(ExperimentalJsExport::class)")
             contains("object AwesomeConfig")
         }
 
-        val wasmJsResult = File(buildDir, "wasmJsMain/com/example/AwesomeConfig.kt")
+        val wasmJsResult = buildKonfigFile(buildDir, "wasmJsMain", "com.example", objectName = "AwesomeConfig")
         Truth.assertThat(wasmJsResult.readText()).apply {
             doesNotContain("@JsExport")
             doesNotContain("@OptIn(ExperimentalJsExport::class)")
@@ -914,20 +728,16 @@ class BuildKonfigPluginFlavorTest {
         """.trimMargin()
         )
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
+        val runner = gradleRunner(projectDir)
 
         // First build with flavor=dev
-        val devResult = runner
+        runner
             .withArguments("generateBuildKonfig", "--stacktrace", "-Pbuildkonfig.flavor=dev")
             .build()
-
-        Truth.assertThat(devResult.output).contains("BUILD SUCCESSFUL")
-        val devCommon = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+            .assertBuildSuccessful()
+        val devCommon = buildKonfigFile(buildDir, "commonMain", "com.example")
         Truth.assertThat(devCommon.readText())
             .contains("val stringValue: String = \"devDefaultValue\"")
 
@@ -935,11 +745,11 @@ class BuildKonfigPluginFlavorTest {
         val releaseResult = runner
             .withArguments("generateBuildKonfig", "--stacktrace", "-Pbuildkonfig.flavor=release")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(releaseResult.output).contains("BUILD SUCCESSFUL")
         Truth.assertThat(releaseResult.output).doesNotContain("generateBuildKonfig UP-TO-DATE")
 
-        val releaseCommon = File(buildDir, "commonMain/com/example/BuildKonfig.kt")
+        val releaseCommon = buildKonfigFile(buildDir, "commonMain", "com.example")
         Truth.assertThat(releaseCommon.readText())
             .contains("val stringValue: String = \"releaseDefaultValue\"")
     }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginGradle9KspTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginGradle9KspTest.kt
@@ -1,12 +1,7 @@
 package com.codingfeline.buildkonfig.gradle
 
 import com.google.common.truth.Truth.assertThat
-import org.gradle.testkit.runner.GradleRunner
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import java.io.File
 
 /**
  * Regression test for issue #236: Gradle 9.0 + KSP combinations failed with an "implicit
@@ -14,23 +9,9 @@ import java.io.File
  * via `kotlin.srcDirs(...)` without a declared task dependency. After the lazy/Provider
  * refactor the source set Provider chain establishes the dependency automatically.
  */
-class BuildKonfigPluginGradle9KspTest {
-
-    @get:Rule
-    val projectDir = TemporaryFolder()
-
-    lateinit var buildFile: File
-
-    lateinit var settingFile: File
+class BuildKonfigPluginGradle9KspTest : BaseGradlePluginTest() {
 
     private val buildFileHeader = buildFileHeader("kotlin-multiplatform", "com.google.devtools.ksp")
-
-    @Before
-    fun setup() {
-        buildFile = projectDir.newFile("build.gradle")
-        settingFile = projectDir.newFile("settings.gradle")
-        settingFile.writeText(settingsGradle)
-    }
 
     @Test
     fun `KSP task does not fail with implicit dependency error on Gradle 9 x`() {
@@ -73,16 +54,12 @@ class BuildKonfigPluginGradle9KspTest {
             """.trimMargin()
         )
 
-        val runner = GradleRunner.create()
+        val result = gradleRunner(projectDir)
             .withGradleVersion("9.3.1")
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
             .withArguments("compileKotlinJvm", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        assertThat(result.output).contains("BUILD SUCCESSFUL")
         // Implicit-dependency error message from Gradle 9.x must not surface.
         assertThat(result.output)
             .doesNotContain("without declaring an explicit or implicit dependency")

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginHMPPTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginHMPPTest.kt
@@ -1,6 +1,6 @@
 package com.codingfeline.buildkonfig.gradle
 
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class BuildKonfigPluginHMPPTest : BaseGradlePluginTest() {
@@ -111,7 +111,7 @@ class BuildKonfigPluginHMPPTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val jvmResult = buildKonfigFile(buildDir, "jvmMain", "com.sample")
-        Truth.assertThat(jvmResult.readText())
+        assertThat(jvmResult.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
                 contains("actual val test: String = \"jvm\"")
@@ -122,7 +122,7 @@ class BuildKonfigPluginHMPPTest : BaseGradlePluginTest() {
             }
 
         val androidResult = buildKonfigFile(buildDir, "customAndroidMain", "com.sample")
-        Truth.assertThat(androidResult.readText())
+        assertThat(androidResult.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
                 contains("actual val test: String = \"hoge\"")
@@ -133,7 +133,7 @@ class BuildKonfigPluginHMPPTest : BaseGradlePluginTest() {
             }
 
         val jsResult = buildKonfigFile(buildDir, "jsMain", "com.sample")
-        Truth.assertThat(jsResult.readText())
+        assertThat(jsResult.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
                 contains("actual val test: String = \"hoge\"")
@@ -143,7 +143,7 @@ class BuildKonfigPluginHMPPTest : BaseGradlePluginTest() {
             }
 
         val iosX64Result = buildKonfigFile(buildDir, "iosX64Main", "com.sample")
-        Truth.assertThat(iosX64Result.readText())
+        assertThat(iosX64Result.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
                 contains("actual val test: String = \"hoge\"")
@@ -154,7 +154,7 @@ class BuildKonfigPluginHMPPTest : BaseGradlePluginTest() {
             }
 
         val iosArm64Result = buildKonfigFile(buildDir, "iosArm64Main", "com.sample")
-        Truth.assertThat(iosArm64Result.readText())
+        assertThat(iosArm64Result.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
                 contains("actual val test: String = \"hoge\"")
@@ -296,60 +296,60 @@ class BuildKonfigPluginHMPPTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val commonKonfig = buildKonfigFile(buildDir, "commonMain", "com.sample")
-        Truth.assertThat(commonKonfig.exists()).isTrue()
-        Truth.assertThat(commonKonfig.readText()).apply {
+        assertThat(commonKonfig.exists()).isTrue()
+        assertThat(commonKonfig.readText()).apply {
             contains("expect")
             doesNotContain("actual")
         }
 
         val appKonfig = buildKonfigFile(buildDir, "appMain", "com.sample")
-        Truth.assertThat(appKonfig.exists()).isTrue()
-        Truth.assertThat(appKonfig.readText()).apply {
+        assertThat(appKonfig.exists()).isTrue()
+        assertThat(appKonfig.readText()).apply {
             contains("actual")
             doesNotContain("expect")
 
             contains("val platform: String = \"app\"")
         }
 
-        Truth.assertThat(buildKonfigFile(buildDir, "androidMain", "com.sample").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "desktopMain", "com.sample").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "macosX64Main", "com.sample").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "linuxX64Main", "com.sample").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "mingwX64Main", "com.sample").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "androidMain", "com.sample").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "desktopMain", "com.sample").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "macosX64Main", "com.sample").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "linuxX64Main", "com.sample").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "mingwX64Main", "com.sample").exists()).isFalse()
 
         val jvmKonfig = buildKonfigFile(buildDir, "jvmMain", "com.sample")
-        Truth.assertThat(jvmKonfig.exists()).isTrue()
-        Truth.assertThat(jvmKonfig.readText()).apply {
+        assertThat(jvmKonfig.exists()).isTrue()
+        assertThat(jvmKonfig.readText()).apply {
             contains("actual")
             doesNotContain("expect")
         }
 
         val appleKonfig = buildKonfigFile(buildDir, "appleMain", "com.sample")
-        Truth.assertThat(appleKonfig.exists()).isTrue()
-        Truth.assertThat(appleKonfig.readText()).apply {
+        assertThat(appleKonfig.exists()).isTrue()
+        assertThat(appleKonfig.readText()).apply {
             contains("actual")
             doesNotContain("expect")
         }
 
         val iosKonfig = buildKonfigFile(buildDir, "iosMain", "com.sample")
-        Truth.assertThat(iosKonfig.exists()).isTrue()
-        Truth.assertThat(iosKonfig.readText()).apply {
+        assertThat(iosKonfig.exists()).isTrue()
+        assertThat(iosKonfig.readText()).apply {
             contains("actual")
             doesNotContain("expect")
         }
 
-        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.sample").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "iosArm64Main", "com.sample").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.sample").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "iosArm64Main", "com.sample").exists()).isFalse()
 
         val jsCommonKonfig = buildKonfigFile(buildDir, "jsCommonMain", "com.sample")
-        Truth.assertThat(jsCommonKonfig.exists()).isTrue()
-        Truth.assertThat(jsCommonKonfig.readText()).apply {
+        assertThat(jsCommonKonfig.exists()).isTrue()
+        assertThat(jsCommonKonfig.readText()).apply {
             contains("actual")
             doesNotContain("expect")
         }
 
-        Truth.assertThat(buildKonfigFile(buildDir, "browserMain", "com.sample").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "nodeMain", "com.sample").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "browserMain", "com.sample").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "nodeMain", "com.sample").exists()).isFalse()
     }
 
     @Test
@@ -448,8 +448,8 @@ class BuildKonfigPluginHMPPTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val appKonfig = buildKonfigFile(buildDir, "appMain", "com.sample")
-        Truth.assertThat(appKonfig.exists()).isTrue()
-        Truth.assertThat(appKonfig.readText()).apply {
+        assertThat(appKonfig.exists()).isTrue()
+        assertThat(appKonfig.readText()).apply {
             contains("actual")
             doesNotContain("expect")
 
@@ -457,12 +457,12 @@ class BuildKonfigPluginHMPPTest : BaseGradlePluginTest() {
             contains("val app: String = \"appvalue\"")
         }
 
-        Truth.assertThat(buildKonfigFile(buildDir, "androidMain", "com.sample").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.sample").exists()).isTrue()
-        Truth.assertThat(buildKonfigFile(buildDir, "iosMain", "com.sample").exists()).isFalse()
-        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.sample").exists()).isTrue()
-        Truth.assertThat(buildKonfigFile(buildDir, "iosArm64Main", "com.sample").exists()).isTrue()
-        Truth.assertThat(buildKonfigFile(buildDir, "browserMain", "com.sample").exists()).isTrue()
-        Truth.assertThat(buildKonfigFile(buildDir, "nodeMain", "com.sample").exists()).isTrue()
+        assertThat(buildKonfigFile(buildDir, "androidMain", "com.sample").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "jvmMain", "com.sample").exists()).isTrue()
+        assertThat(buildKonfigFile(buildDir, "iosMain", "com.sample").exists()).isFalse()
+        assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.sample").exists()).isTrue()
+        assertThat(buildKonfigFile(buildDir, "iosArm64Main", "com.sample").exists()).isTrue()
+        assertThat(buildKonfigFile(buildDir, "browserMain", "com.sample").exists()).isTrue()
+        assertThat(buildKonfigFile(buildDir, "nodeMain", "com.sample").exists()).isTrue()
     }
 }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginHMPPTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginHMPPTest.kt
@@ -1,40 +1,17 @@
 package com.codingfeline.buildkonfig.gradle
 
 import com.google.common.truth.Truth
-import org.gradle.testkit.runner.GradleRunner
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import java.io.File
 
-class BuildKonfigPluginHMPPTest {
+class BuildKonfigPluginHMPPTest : BaseGradlePluginTest() {
 
-    @get:Rule
-    val projectDir = TemporaryFolder()
-
-    lateinit var buildFile: File
-
-    lateinit var settingFile: File
-
-    private val buildFileHeader = buildFileHeader("kotlin-multiplatform")
-
-    @Before
-    fun setup() {
-        buildFile = projectDir.newFile("build.gradle")
-        settingFile = projectDir.newFile("settings.gradle")
-        settingFile.writeText(settingsGradle)
-
-        projectDir.newFile("gradle.properties")
-            .also {
-                it.writeText(
-                    """
-                        kotlin.mpp.androidSourceSetLayoutVersion=2
-                        kotlin.js.compiler=ir
-                        """.trimMargin()
-                )
-            }
-
+    override fun extraSetup() {
+        projectDir.newFile("gradle.properties").writeText(
+            """
+                kotlin.mpp.androidSourceSetLayoutVersion=2
+                kotlin.js.compiler=ir
+                """.trimMargin()
+        )
     }
 
     @Test
@@ -73,7 +50,7 @@ class BuildKonfigPluginHMPPTest {
             |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
             |        }
             |    }
-            |    
+            |
             |    namespace = "com.sample"
             |}
             |buildkonfig {
@@ -107,7 +84,7 @@ class BuildKonfigPluginHMPPTest {
             |   }
             |   iosX64()
             |   iosArm64()
-            |   iosSimulatorArm64() 
+            |   iosSimulatorArm64()
             |
             |   sourceSets {
             |     commonMain {
@@ -126,23 +103,14 @@ class BuildKonfigPluginHMPPTest {
 
         createAndroidManifest(projectDir)
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace", "--info")
             .build()
+            .assertBuildSuccessful()
 
-//        println("result: ${result.output}")
-
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val jvmResult = File(buildDir, "jvmMain/com/sample/BuildKonfig.kt")
+        val jvmResult = buildKonfigFile(buildDir, "jvmMain", "com.sample")
         Truth.assertThat(jvmResult.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
@@ -153,7 +121,7 @@ class BuildKonfigPluginHMPPTest {
                 doesNotContain("native")
             }
 
-        val androidResult = File(buildDir, "customAndroidMain/com/sample/BuildKonfig.kt")
+        val androidResult = buildKonfigFile(buildDir, "customAndroidMain", "com.sample")
         Truth.assertThat(androidResult.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
@@ -164,7 +132,7 @@ class BuildKonfigPluginHMPPTest {
                 doesNotContain("native")
             }
 
-        val jsResult = File(buildDir, "jsMain/com/sample/BuildKonfig.kt")
+        val jsResult = buildKonfigFile(buildDir, "jsMain", "com.sample")
         Truth.assertThat(jsResult.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
@@ -174,7 +142,7 @@ class BuildKonfigPluginHMPPTest {
                 doesNotContain("native")
             }
 
-        val iosX64Result = File(buildDir, "iosX64Main/com/sample/BuildKonfig.kt")
+        val iosX64Result = buildKonfigFile(buildDir, "iosX64Main", "com.sample")
         Truth.assertThat(iosX64Result.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
@@ -185,7 +153,7 @@ class BuildKonfigPluginHMPPTest {
                 doesNotContain("jvm")
             }
 
-        val iosArm64Result = File(buildDir, "iosArm64Main/com/sample/BuildKonfig.kt")
+        val iosArm64Result = buildKonfigFile(buildDir, "iosArm64Main", "com.sample")
         Truth.assertThat(iosArm64Result.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
@@ -233,7 +201,7 @@ class BuildKonfigPluginHMPPTest {
             |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
             |        }
             |    }
-            |    
+            |
             |    namespace = "com.sample"
             |}
             |buildkonfig {
@@ -282,18 +250,18 @@ class BuildKonfigPluginHMPPTest {
             |    macosX64()
             |    linuxX64()
             |    mingwX64()
-            |    
+            |
             |    applyDefaultHierarchyTemplate()
             |
             |    sourceSets {
             |     commonMain {}
             |     androidMain {}
             |     jvmMain {}
-            |     
+            |
             |     appMain {
             |       dependsOn(commonMain)
             |     }
-            |     
+            |
             |     androidMain {
             |       dependsOn(appMain)
             |     }
@@ -309,7 +277,7 @@ class BuildKonfigPluginHMPPTest {
             |     mingwX64Main {
             |       dependsOn(desktopMain)
             |     }
-            |     
+            |
             |     jsCommonMain {
             |       dependsOn(commonMain)
             |     }
@@ -320,30 +288,21 @@ class BuildKonfigPluginHMPPTest {
 
         createAndroidManifest(projectDir)
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace", "--info")
             .build()
+            .assertBuildSuccessful()
 
-//        println("result: ${result.output}")
-
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val commonKonfig = File(buildDir, "commonMain/com/sample/BuildKonfig.kt")
+        val commonKonfig = buildKonfigFile(buildDir, "commonMain", "com.sample")
         Truth.assertThat(commonKonfig.exists()).isTrue()
         Truth.assertThat(commonKonfig.readText()).apply {
             contains("expect")
             doesNotContain("actual")
         }
 
-        val appKonfig = File(buildDir, "appMain/com/sample/BuildKonfig.kt")
+        val appKonfig = buildKonfigFile(buildDir, "appMain", "com.sample")
         Truth.assertThat(appKonfig.exists()).isTrue()
         Truth.assertThat(appKonfig.readText()).apply {
             contains("actual")
@@ -352,60 +311,45 @@ class BuildKonfigPluginHMPPTest {
             contains("val platform: String = \"app\"")
         }
 
-        val androidKonfig = File(buildDir, "androidMain/com/sample/BuildKonfig.kt")
-        Truth.assertThat(androidKonfig.exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "androidMain", "com.sample").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "desktopMain", "com.sample").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "macosX64Main", "com.sample").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "linuxX64Main", "com.sample").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "mingwX64Main", "com.sample").exists()).isFalse()
 
-        val desktopKonfig = File(buildDir, "desktopMain/com/sample/BuildKonfig.kt")
-        Truth.assertThat(desktopKonfig.exists()).isFalse()
-
-        val macosX64Konfig = File(buildDir, "macosX64Main/com/sample/BuildKonfig.kt")
-        Truth.assertThat(macosX64Konfig.exists()).isFalse()
-
-        val linuxX64Konfig = File(buildDir, "linuxX64Main/com/sample/BuildKonfig.kt")
-        Truth.assertThat(linuxX64Konfig.exists()).isFalse()
-
-        val mingwX64Konfig = File(buildDir, "mingwX64Main/com/sample/BuildKonfig.kt")
-        Truth.assertThat(mingwX64Konfig.exists()).isFalse()
-
-        val jvmKonfig = File(buildDir, "jvmMain/com/sample/BuildKonfig.kt")
+        val jvmKonfig = buildKonfigFile(buildDir, "jvmMain", "com.sample")
         Truth.assertThat(jvmKonfig.exists()).isTrue()
         Truth.assertThat(jvmKonfig.readText()).apply {
             contains("actual")
             doesNotContain("expect")
         }
 
-        val appleKonfig = File(buildDir, "appleMain/com/sample/BuildKonfig.kt")
+        val appleKonfig = buildKonfigFile(buildDir, "appleMain", "com.sample")
         Truth.assertThat(appleKonfig.exists()).isTrue()
         Truth.assertThat(appleKonfig.readText()).apply {
             contains("actual")
             doesNotContain("expect")
         }
 
-        val iosKonfig = File(buildDir, "iosMain/com/sample/BuildKonfig.kt")
+        val iosKonfig = buildKonfigFile(buildDir, "iosMain", "com.sample")
         Truth.assertThat(iosKonfig.exists()).isTrue()
         Truth.assertThat(iosKonfig.readText()).apply {
             contains("actual")
             doesNotContain("expect")
         }
 
-        val iosX64Konfig = File(buildDir, "iosX64Main/com/sample/BuildKonfig.kt")
-        Truth.assertThat(iosX64Konfig.exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.sample").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "iosArm64Main", "com.sample").exists()).isFalse()
 
-        val iosArm64Konfig = File(buildDir, "iosArm64Main/com/sample/BuildKonfig.kt")
-        Truth.assertThat(iosArm64Konfig.exists()).isFalse()
-
-        val jsCommonKonfig = File(buildDir, "jsCommonMain/com/sample/BuildKonfig.kt")
+        val jsCommonKonfig = buildKonfigFile(buildDir, "jsCommonMain", "com.sample")
         Truth.assertThat(jsCommonKonfig.exists()).isTrue()
         Truth.assertThat(jsCommonKonfig.readText()).apply {
             contains("actual")
             doesNotContain("expect")
         }
 
-        val browserKonfig = File(buildDir, "browserMain/com/sample/BuildKonfig.kt")
-        Truth.assertThat(browserKonfig.exists()).isFalse()
-
-        val nodeKonfig = File(buildDir, "nodeMain/com/sample/BuildKonfig.kt")
-        Truth.assertThat(nodeKonfig.exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "browserMain", "com.sample").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "nodeMain", "com.sample").exists()).isFalse()
     }
 
     @Test
@@ -444,7 +388,7 @@ class BuildKonfigPluginHMPPTest {
             |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
             |        }
             |    }
-            |    
+            |
             |    namespace = "com.sample"
             |}
             |buildkonfig {
@@ -496,23 +440,14 @@ class BuildKonfigPluginHMPPTest {
 
         createAndroidManifest(projectDir)
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace", "--info")
             .build()
+            .assertBuildSuccessful()
 
-//        println("result: ${result.output}")
-
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val appKonfig = File(buildDir, "appMain/com/sample/BuildKonfig.kt")
+        val appKonfig = buildKonfigFile(buildDir, "appMain", "com.sample")
         Truth.assertThat(appKonfig.exists()).isTrue()
         Truth.assertThat(appKonfig.readText()).apply {
             contains("actual")
@@ -522,25 +457,12 @@ class BuildKonfigPluginHMPPTest {
             contains("val app: String = \"appvalue\"")
         }
 
-        val androidKonfig = File(buildDir, "androidMain/com/sample/BuildKonfig.kt")
-        Truth.assertThat(androidKonfig.exists()).isFalse()
-
-        val jvmKonfig = File(buildDir, "jvmMain/com/sample/BuildKonfig.kt")
-        Truth.assertThat(jvmKonfig.exists()).isTrue()
-
-        val iosKonfig = File(buildDir, "iosMain/com/sample/BuildKonfig.kt")
-        Truth.assertThat(iosKonfig.exists()).isFalse()
-
-        val iosX64Konfig = File(buildDir, "iosX64Main/com/sample/BuildKonfig.kt")
-        Truth.assertThat(iosX64Konfig.exists()).isTrue()
-
-        val iosArm64Konfig = File(buildDir, "iosArm64Main/com/sample/BuildKonfig.kt")
-        Truth.assertThat(iosArm64Konfig.exists()).isTrue()
-
-        val browserKonfig = File(buildDir, "browserMain/com/sample/BuildKonfig.kt")
-        Truth.assertThat(browserKonfig.exists()).isTrue()
-
-        val nodeKonfig = File(buildDir, "nodeMain/com/sample/BuildKonfig.kt")
-        Truth.assertThat(nodeKonfig.exists()).isTrue()
+        Truth.assertThat(buildKonfigFile(buildDir, "androidMain", "com.sample").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "jvmMain", "com.sample").exists()).isTrue()
+        Truth.assertThat(buildKonfigFile(buildDir, "iosMain", "com.sample").exists()).isFalse()
+        Truth.assertThat(buildKonfigFile(buildDir, "iosX64Main", "com.sample").exists()).isTrue()
+        Truth.assertThat(buildKonfigFile(buildDir, "iosArm64Main", "com.sample").exists()).isTrue()
+        Truth.assertThat(buildKonfigFile(buildDir, "browserMain", "com.sample").exists()).isTrue()
+        Truth.assertThat(buildKonfigFile(buildDir, "nodeMain", "com.sample").exists()).isTrue()
     }
 }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginKotlinDSLFlavorTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginKotlinDSLFlavorTest.kt
@@ -1,6 +1,6 @@
 package com.codingfeline.buildkonfig.gradle
 
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class BuildKonfigPluginKotlinDSLFlavorTest : BaseGradlePluginTest() {
@@ -63,18 +63,18 @@ class BuildKonfigPluginKotlinDSLFlavorTest : BaseGradlePluginTest() {
             .assertBuildSuccessful()
 
         val jvmResult = buildKonfigFile(buildDir, "jvmMain", "com.example")
-        Truth.assertThat(jvmResult.readText())
+        assertThat(jvmResult.readText())
             .contains("defaultValue")
 
         val jsResult = buildKonfigFile(buildDir, "jsMain", "com.example")
-        Truth.assertThat(jsResult.readText())
+        assertThat(jsResult.readText())
             .apply {
                 contains("foobar")
                 contains("devJsValue")
             }
 
         val iosResult = buildKonfigFile(buildDir, "iosX64Main", "com.example")
-        Truth.assertThat(iosResult.readText())
+        assertThat(iosResult.readText())
             .contains("defaultValue")
     }
 }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginKotlinDSLFlavorTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginKotlinDSLFlavorTest.kt
@@ -52,8 +52,7 @@ class BuildKonfigPluginKotlinDSLFlavorTest : BaseGradlePluginTest() {
             """.trimMargin()
         )
 
-        val propertyFile = projectDir.newFile("gradle.properties")
-        propertyFile.writeText("buildkonfig.flavor=dev")
+        projectDir.newFile("gradle.properties").writeText("buildkonfig.flavor=dev")
 
         val buildDir = projectDir.buildKonfigDir()
 

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginKotlinDSLFlavorTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginKotlinDSLFlavorTest.kt
@@ -1,21 +1,11 @@
 package com.codingfeline.buildkonfig.gradle
 
 import com.google.common.truth.Truth
-import org.gradle.testkit.runner.GradleRunner
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import java.io.File
 
-class BuildKonfigPluginKotlinDSLFlavorTest {
+class BuildKonfigPluginKotlinDSLFlavorTest : BaseGradlePluginTest() {
 
-    @get:Rule
-    val projectDir = TemporaryFolder()
-
-    lateinit var buildFile: File
-
-    lateinit var settingFile: File
+    override val buildFileName: String = "build.gradle.kts"
 
     private val buildFileHeader = buildFileHeaderKts("kotlin-multiplatform")
 
@@ -32,13 +22,6 @@ class BuildKonfigPluginKotlinDSLFlavorTest {
         |}
     """.trimMargin()
 
-    @Before
-    fun setup() {
-        buildFile = projectDir.newFile("build.gradle.kts")
-        settingFile = projectDir.newFile("settings.gradle")
-        settingFile.writeText(settingsGradle)
-    }
-
     @Test
     fun `Flavored targetConfigs overwrites default targetConfigs`() {
         buildFile.writeText(
@@ -48,7 +31,7 @@ class BuildKonfigPluginKotlinDSLFlavorTest {
             |
             |buildkonfig {
             |   packageName = "com.example"
-            |   
+            |
             |   defaultConfigs {
             |       buildConfigField(Type.STRING, "value", "defaultValue")
             |   }
@@ -72,32 +55,25 @@ class BuildKonfigPluginKotlinDSLFlavorTest {
         val propertyFile = projectDir.newFile("gradle.properties")
         propertyFile.writeText("buildkonfig.flavor=dev")
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        Truth.assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val jvmResult = File(buildDir, "jvmMain/com/example/BuildKonfig.kt")
+        val jvmResult = buildKonfigFile(buildDir, "jvmMain", "com.example")
         Truth.assertThat(jvmResult.readText())
             .contains("defaultValue")
 
-        val jsResult = File(buildDir, "jsMain/com/example/BuildKonfig.kt")
+        val jsResult = buildKonfigFile(buildDir, "jsMain", "com.example")
         Truth.assertThat(jsResult.readText())
             .apply {
                 contains("foobar")
                 contains("devJsValue")
             }
 
-        val iosResult = File(buildDir, "iosX64Main/com/example/BuildKonfig.kt")
+        val iosResult = buildKonfigFile(buildDir, "iosX64Main", "com.example")
         Truth.assertThat(iosResult.readText())
             .contains("defaultValue")
     }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginNonKmpTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginNonKmpTest.kt
@@ -1,30 +1,12 @@
 package com.codingfeline.buildkonfig.gradle
 
 import com.google.common.truth.Truth.assertThat
-import org.gradle.testkit.runner.GradleRunner
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
 import java.io.File
 
-class BuildKonfigPluginNonKmpTest {
-
-    @get:Rule
-    val projectDir = TemporaryFolder()
-
-    lateinit var buildFile: File
-
-    lateinit var settingFile: File
+class BuildKonfigPluginNonKmpTest : BaseGradlePluginTest() {
 
     private val jvmBuildFileHeader = buildFileHeader("org.jetbrains.kotlin.jvm")
-
-    @Before
-    fun setup() {
-        buildFile = projectDir.newFile("build.gradle")
-        settingFile = projectDir.newFile("settings.gradle")
-        settingFile.writeText(settingsGradle)
-    }
 
     @Test
     fun `Applying plugin to a Kotlin JVM project generates a single concrete object`() {
@@ -43,20 +25,14 @@ class BuildKonfigPluginNonKmpTest {
             """.trimMargin()
         )
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        assertThat(result.output).contains("BUILD SUCCESSFUL")
-
-        val generated = File(buildDir, "main/com/sample/BuildKonfig.kt")
+        val generated = buildKonfigFile(buildDir, "main", "com.sample")
         assertThat(generated.exists()).isTrue()
         val content = generated.readText()
         assertThat(content).contains("internal object BuildKonfig")
@@ -95,15 +71,10 @@ class BuildKonfigPluginNonKmpTest {
             """.trimIndent()
         )
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("compileKotlin", "--stacktrace")
             .build()
-
-        assertThat(result.output).contains("BUILD SUCCESSFUL")
+            .assertBuildSuccessful()
     }
 
     @Test
@@ -125,19 +96,14 @@ class BuildKonfigPluginNonKmpTest {
             """.trimMargin()
         )
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "-Pbuildkonfig.flavor=staging", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        assertThat(result.output).contains("BUILD SUCCESSFUL")
-        val generated = File(buildDir, "main/com/sample/BuildKonfig.kt")
+        val generated = buildKonfigFile(buildDir, "main", "com.sample")
         assertThat(generated.readText()).contains("public val env: String = \"staging\"")
     }
 
@@ -177,19 +143,14 @@ class BuildKonfigPluginNonKmpTest {
         val srcDir = projectDir.newFolder("src", "main", "kotlin")
         File(srcDir, "Main.kt").writeText("fun main() {}")
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        assertThat(result.output).contains("BUILD SUCCESSFUL")
-        val generated = File(buildDir, "main/com/sample/BuildKonfig.kt")
+        val generated = buildKonfigFile(buildDir, "main", "com.sample")
         assertThat(generated.exists()).isTrue()
         val content = generated.readText()
         assertThat(content).contains("@JsExport")
@@ -212,9 +173,7 @@ class BuildKonfigPluginNonKmpTest {
             """.trimMargin()
         )
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
+        val runner = gradleRunner(projectDir)
 
         val firstRun = runner
             .withArguments(
@@ -258,22 +217,17 @@ class BuildKonfigPluginNonKmpTest {
             """.trimMargin()
         )
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        val result = gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        assertThat(result.output).contains("BUILD SUCCESSFUL")
         assertThat(result.output)
             .contains("BuildKonfig: targetConfigs are ignored in non-multiplatform projects")
 
-        val generated = File(buildDir, "main/com/sample/BuildKonfig.kt")
+        val generated = buildKonfigFile(buildDir, "main", "com.sample")
         assertThat(generated.exists()).isTrue()
         val content = generated.readText()
         // The defaultConfigs value wins; no expect/actual was generated.

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginTest.kt
@@ -1,21 +1,9 @@
 package com.codingfeline.buildkonfig.gradle
 
 import com.google.common.truth.Truth.assertThat
-import org.gradle.testkit.runner.GradleRunner
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import java.io.File
 
-class BuildKonfigPluginTest {
-
-    @get:Rule
-    val projectDir = TemporaryFolder()
-
-    lateinit var buildFile: File
-
-    lateinit var settingFile: File
+class BuildKonfigPluginTest : BaseGradlePluginTest() {
 
     private val buildFileHeader = buildFileHeader("kotlin-multiplatform")
 
@@ -39,21 +27,13 @@ class BuildKonfigPluginTest {
         |}
     """.trimMargin()
 
-    @Before
-    fun setup() {
-        buildFile = projectDir.newFile("build.gradle")
-        settingFile = projectDir.newFile("settings.gradle")
-        settingFile.writeText(settingsGradle)
-
-        projectDir.newFile("gradle.properties")
-            .also {
-                it.writeText(
-                    """
-                        kotlin.mpp.androidSourceSetLayoutVersion=2
-                        kotlin.js.compiler=ir
-                        """.trimMargin()
-                )
-            }
+    override fun extraSetup() {
+        projectDir.newFile("gradle.properties").writeText(
+            """
+                kotlin.mpp.androidSourceSetLayoutVersion=2
+                kotlin.js.compiler=ir
+                """.trimMargin()
+        )
     }
 
     @Test
@@ -78,14 +58,9 @@ class BuildKonfigPluginTest {
             """.trimMargin()
         )
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        val result = gradleRunner(projectDir)
             .withArguments("build", "--stacktrace")
             .buildAndFail()
 
@@ -130,21 +105,15 @@ class BuildKonfigPluginTest {
             """.trimMargin()
         )
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        val result = gradleRunner(projectDir)
             .withArguments("build", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
         assertThat(result.output)
             .contains("BuildKonfig: non-flavored defaultConfigs is not provided. Skipping code generation.")
-        assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
     }
 
     @Test
@@ -165,14 +134,9 @@ class BuildKonfigPluginTest {
             """.trimMargin()
         )
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        val result = gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .buildAndFail()
 
@@ -216,7 +180,7 @@ class BuildKonfigPluginTest {
             |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
             |        }
             |    }
-            |    
+            |
             |    namespace = "com.sample"
             |}
             |buildkonfig {
@@ -267,21 +231,14 @@ class BuildKonfigPluginTest {
 
         createAndroidManifest(projectDir)
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-        assertThat(result.output)
-            .contains("BUILD SUCCESSFUL")
-
-        val jvmResult = File(buildDir, "jvmMain/com/sample/BuildKonfig.kt")
+        val jvmResult = buildKonfigFile(buildDir, "jvmMain", "com.sample")
         assertThat(jvmResult.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
@@ -292,7 +249,7 @@ class BuildKonfigPluginTest {
                 doesNotContain("native")
             }
 
-        val androidResult = File(buildDir, "customAndroidMain/com/sample/BuildKonfig.kt")
+        val androidResult = buildKonfigFile(buildDir, "customAndroidMain", "com.sample")
         assertThat(androidResult.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
@@ -303,7 +260,7 @@ class BuildKonfigPluginTest {
                 doesNotContain("native")
             }
 
-        val jsResult = File(buildDir, "jsMain/com/sample/BuildKonfig.kt")
+        val jsResult = buildKonfigFile(buildDir, "jsMain", "com.sample")
         assertThat(jsResult.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
@@ -313,7 +270,7 @@ class BuildKonfigPluginTest {
                 doesNotContain("native")
             }
 
-        val iosResult = File(buildDir, "iosX64Main/com/sample/BuildKonfig.kt")
+        val iosResult = buildKonfigFile(buildDir, "iosX64Main", "com.sample")
         assertThat(iosResult.readText())
             .apply {
                 contains("actual val intValue: Int = 10")
@@ -327,100 +284,13 @@ class BuildKonfigPluginTest {
 
     @Test
     fun `The generate task is a dependency of multiplatform jvm target`() {
-
-        buildFile.writeText(
-            """
-            |plugins {
-            |   id 'kotlin-multiplatform'
-            |   id 'com.android.library'
-            |   id 'com.codingfeline.buildkonfig'
-            |}
-            |
-            |repositories {
-            |   google()
-            |   mavenCentral()
-            |}
-            |
-            |android {
-            |    compileSdkVersion 28
-            |
-            |    defaultConfig {
-            |        minSdkVersion 21
-            |        targetSdkVersion 28
-            |        versionCode 1
-            |        versionName "1.0"
-            |    }
-            |    buildTypes {
-            |        release {
-            |            minifyEnabled false
-            |            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            |        }
-            |    }
-            |
-            |    sourceSets {
-            |        main {
-            |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
-            |        }
-            |    }
-            |    
-            |    namespace = "com.sample"
-            |}
-            |buildkonfig {
-            |    packageName = "com.sample"
-            |
-            |    defaultConfigs {
-            |        buildConfigField 'STRING', 'test', 'hoge'
-            |        buildConfigField 'INT', 'intValue', '10'
-            |    }
-            |
-            |    targetConfigs {
-            |        jvm {
-            |            buildConfigField 'STRING', 'test', 'jvm'
-            |            buildConfigField 'STRING', 'jvm', 'jvmHoge'
-            |        }
-            |        customAndroid {
-            |            buildConfigField 'String', 'android', '${'$'}fuga'
-            |        }
-            |        iosX64 {
-            |            buildConfigField 'BOOLEAN', 'native', 'true'
-            |        }
-            |    }
-            |}
-            |
-            |kotlin {
-            |   androidTarget('customAndroid')
-            |   jvm()
-            |   js {
-            |    browser()
-            |    nodejs()
-            |   }
-            |   iosX64()
-            |
-            |   sourceSets {
-            |     commonMain {
-            |       dependencies {}
-            |     }
-            |     customAndroidMain {
-            |       dependencies {}
-            |     }
-            |     jvmMain {
-            |       dependencies {}
-            |     }
-            |   }
-            |}
-            """.trimMargin()
-        )
+        buildFile.writeText(buildKMPAndroidScript())
 
         createAndroidManifest(projectDir)
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        val result = gradleRunner(projectDir)
             .withArguments("compileKotlinJvm", "--stacktrace")
             .build()
 
@@ -430,100 +300,13 @@ class BuildKonfigPluginTest {
 
     @Test
     fun `The generate task is a dependency of multiplatform jvm test target`() {
-        buildFile.writeText(
-            """
-            |plugins {
-            |   id 'kotlin-multiplatform'
-            |   id 'com.android.library'
-            |   id 'com.codingfeline.buildkonfig'
-            |}
-            |
-            |
-            |repositories {
-            |   google()
-            |   mavenCentral()
-            |}
-            |
-            |android {
-            |    compileSdkVersion 28
-            |
-            |    defaultConfig {
-            |        minSdkVersion 21
-            |        targetSdkVersion 28
-            |        versionCode 1
-            |        versionName "1.0"
-            |    }
-            |    buildTypes {
-            |        release {
-            |            minifyEnabled false
-            |            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            |        }
-            |    }
-            |
-            |    sourceSets {
-            |        main {
-            |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
-            |        }
-            |    }
-            |    
-            |    namespace = "com.sample"
-            |}
-            |buildkonfig {
-            |    packageName = "com.sample"
-            |
-            |    defaultConfigs {
-            |        buildConfigField 'STRING', 'test', 'hoge'
-            |        buildConfigField 'INT', 'intValue', '10'
-            |    }
-            |
-            |    targetConfigs {
-            |        jvm {
-            |            buildConfigField 'STRING', 'test', 'jvm'
-            |            buildConfigField 'STRING', 'jvm', 'jvmHoge'
-            |        }
-            |        customAndroid {
-            |            buildConfigField 'String', 'android', '${'$'}fuga'
-            |        }
-            |        iosX64 {
-            |            buildConfigField 'BOOLEAN', 'native', 'true'
-            |        }
-            |    }
-            |}
-            |
-            |kotlin {
-            |   androidTarget('customAndroid')
-            |   jvm()
-            |   js {
-            |    browser()
-            |    nodejs()
-            |   }
-            |   iosX64()
-            |
-            |   sourceSets {
-            |     commonMain {
-            |       dependencies {}
-            |     }
-            |     customAndroidMain {
-            |       dependencies {}
-            |     }
-            |     jvmMain {
-            |       dependencies {}
-            |     }
-            |   }
-            |}
-            """.trimMargin()
-        )
+        buildFile.writeText(buildKMPAndroidScript())
 
         createAndroidManifest(projectDir)
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        val result = gradleRunner(projectDir)
             .withArguments("compileTestKotlinJvm", "--stacktrace")
             .build()
 
@@ -533,99 +316,13 @@ class BuildKonfigPluginTest {
 
     @Test
     fun `The generate task is a dependency of multiplatform js target`() {
-        buildFile.writeText(
-            """
-            |plugins {
-            |   id 'kotlin-multiplatform'
-            |   id 'com.android.library'
-            |   id 'com.codingfeline.buildkonfig'
-            |}
-            |
-            |repositories {
-            |   google()
-            |   mavenCentral()
-            |}
-            |
-            |android {
-            |    compileSdkVersion 28
-            |
-            |    defaultConfig {
-            |        minSdkVersion 21
-            |        targetSdkVersion 28
-            |        versionCode 1
-            |        versionName "1.0"
-            |    }
-            |    buildTypes {
-            |        release {
-            |            minifyEnabled false
-            |            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            |        }
-            |    }
-            |
-            |    sourceSets {
-            |        main {
-            |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
-            |        }
-            |    }
-            |    
-            |    namespace = "com.sample"
-            |}
-            |buildkonfig {
-            |    packageName = "com.sample"
-            |
-            |    defaultConfigs {
-            |        buildConfigField 'STRING', 'test', 'hoge'
-            |        buildConfigField 'INT', 'intValue', '10'
-            |    }
-            |
-            |    targetConfigs {
-            |        jvm {
-            |            buildConfigField 'STRING', 'test', 'jvm'
-            |            buildConfigField 'STRING', 'jvm', 'jvmHoge'
-            |        }
-            |        customAndroid {
-            |            buildConfigField 'String', 'android', '${'$'}fuga'
-            |        }
-            |        iosX64 {
-            |            buildConfigField 'BOOLEAN', 'native', 'true'
-            |        }
-            |    }
-            |}
-            |
-            |kotlin {
-            |   androidTarget('customAndroid')
-            |   jvm()
-            |   js {
-            |    browser()
-            |    nodejs()
-            |   }
-            |   iosX64()
-            |
-            |   sourceSets {
-            |     commonMain {
-            |       dependencies {}
-            |     }
-            |     customAndroidMain {
-            |       dependencies {}
-            |     }
-            |     jvmMain {
-            |       dependencies {}
-            |     }
-            |   }
-            |}
-            """.trimMargin()
-        )
+        buildFile.writeText(buildKMPAndroidScript())
 
         createAndroidManifest(projectDir)
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        val result = gradleRunner(projectDir)
             .withArguments("compileKotlinJs", "--stacktrace")
             .build()
 
@@ -633,5 +330,85 @@ class BuildKonfigPluginTest {
             .contains("generateBuildKonfig")
     }
 
-
+    private fun buildKMPAndroidScript(): String =
+        """
+        |plugins {
+        |   id 'kotlin-multiplatform'
+        |   id 'com.android.library'
+        |   id 'com.codingfeline.buildkonfig'
+        |}
+        |
+        |repositories {
+        |   google()
+        |   mavenCentral()
+        |}
+        |
+        |android {
+        |    compileSdkVersion 28
+        |
+        |    defaultConfig {
+        |        minSdkVersion 21
+        |        targetSdkVersion 28
+        |        versionCode 1
+        |        versionName "1.0"
+        |    }
+        |    buildTypes {
+        |        release {
+        |            minifyEnabled false
+        |            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        |        }
+        |    }
+        |
+        |    sourceSets {
+        |        main {
+        |            manifest.srcFile 'src/androidMain/AndroidManifest.xml'
+        |        }
+        |    }
+        |
+        |    namespace = "com.sample"
+        |}
+        |buildkonfig {
+        |    packageName = "com.sample"
+        |
+        |    defaultConfigs {
+        |        buildConfigField 'STRING', 'test', 'hoge'
+        |        buildConfigField 'INT', 'intValue', '10'
+        |    }
+        |
+        |    targetConfigs {
+        |        jvm {
+        |            buildConfigField 'STRING', 'test', 'jvm'
+        |            buildConfigField 'STRING', 'jvm', 'jvmHoge'
+        |        }
+        |        customAndroid {
+        |            buildConfigField 'String', 'android', '${'$'}fuga'
+        |        }
+        |        iosX64 {
+        |            buildConfigField 'BOOLEAN', 'native', 'true'
+        |        }
+        |    }
+        |}
+        |
+        |kotlin {
+        |   androidTarget('customAndroid')
+        |   jvm()
+        |   js {
+        |    browser()
+        |    nodejs()
+        |   }
+        |   iosX64()
+        |
+        |   sourceSets {
+        |     commonMain {
+        |       dependencies {}
+        |     }
+        |     customAndroidMain {
+        |       dependencies {}
+        |     }
+        |     jvmMain {
+        |       dependencies {}
+        |     }
+        |   }
+        |}
+        """.trimMargin()
 }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildkonfigPluginKotlinDSLTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildkonfigPluginKotlinDSLTest.kt
@@ -1,28 +1,11 @@
 package com.codingfeline.buildkonfig.gradle
 
 import com.google.common.truth.Truth.assertThat
-import org.gradle.testkit.runner.GradleRunner
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import java.io.File
 
-class BuildkonfigPluginKotlinDSLTest {
+class BuildkonfigPluginKotlinDSLTest : BaseGradlePluginTest() {
 
-    @get:Rule
-    val projectDir = TemporaryFolder()
-
-    lateinit var buildFile: File
-
-    lateinit var settingFile: File
-
-    @Before
-    fun setup() {
-        buildFile = projectDir.newFile("build.gradle.kts")
-        settingFile = projectDir.newFile("settings.gradle")
-        settingFile.writeText(settingsGradle)
-    }
+    override val buildFileName: String = "build.gradle.kts"
 
     @Test
     fun `issue 50 - js(IR) target`() {
@@ -47,7 +30,7 @@ class BuildkonfigPluginKotlinDSLTest {
             |    js(IR) {
             |        browser()
             |    }
-            |    
+            |
             |    applyDefaultHierarchyTemplate()
             |
             |    sourceSets {
@@ -76,7 +59,7 @@ class BuildkonfigPluginKotlinDSLTest {
             |        minSdkVersion(21)
             |        targetSdkVersion(30)
             |    }
-            |    
+            |
             |    namespace = "com.sample"
             |}
             """.trimMargin()
@@ -84,28 +67,20 @@ class BuildkonfigPluginKotlinDSLTest {
 
         createAndroidManifest(projectDir)
 
-        val buildDir = File(projectDir.root, "build/buildkonfig")
-        buildDir.deleteRecursively()
+        val buildDir = projectDir.buildKonfigDir()
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.root)
-            .withPluginClasspath()
-
-        val result = runner
+        gradleRunner(projectDir)
             .withArguments("generateBuildKonfig", "--stacktrace")
             .build()
+            .assertBuildSuccessful()
 
-//        println(result.output)
-
-        assertThat(result.output).contains("BUILD SUCCESSFUL")
-
-        val commonResult = File(buildDir, "commonMain/com/sample/buildkonfig/issues/BuildKonfig.kt")
+        val commonResult = buildKonfigFile(buildDir, "commonMain", "com.sample.buildkonfig.issues")
         assertThat(commonResult.exists()).isTrue()
 
-        val androidResult = File(buildDir, "androidMain/com/sample/buildkonfig/issues/BuildKonfig.kt")
+        val androidResult = buildKonfigFile(buildDir, "androidMain", "com.sample.buildkonfig.issues")
         assertThat(androidResult.exists()).isFalse()
 
-        val jsResult = File(buildDir, "jsMain/com/sample/buildkonfig/issues/BuildKonfig.kt")
+        val jsResult = buildKonfigFile(buildDir, "jsMain", "com.sample.buildkonfig.issues")
         assertThat(jsResult.exists()).isFalse()
     }
 }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/TestUtils.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/TestUtils.kt
@@ -1,6 +1,52 @@
 package com.codingfeline.buildkonfig.gradle
 
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
 import org.junit.rules.TemporaryFolder
+import java.io.File
+
+const val BUILDKONFIG_BUILD_DIR = "build/buildkonfig"
+
+/**
+ * Returns the (freshly cleaned) `build/buildkonfig` directory under [TemporaryFolder.getRoot].
+ * Tests assert on files inside this directory, so they need a clean slate per run.
+ */
+fun TemporaryFolder.buildKonfigDir(): File =
+    File(root, BUILDKONFIG_BUILD_DIR).also { it.deleteRecursively() }
+
+/**
+ * Standard `GradleRunner` configured against [projectDir] with the plugin under test on
+ * the classpath. Tests should chain `.withArguments(...)` and `.build()` /
+ * `.buildAndFail()` as usual.
+ */
+fun gradleRunner(projectDir: TemporaryFolder): GradleRunner =
+    GradleRunner.create()
+        .withProjectDir(projectDir.root)
+        .withPluginClasspath()
+
+/**
+ * Asserts that the build output contains `BUILD SUCCESSFUL`. Returns the receiver so the
+ * call can be chained with further assertions on the same [BuildResult].
+ */
+fun BuildResult.assertBuildSuccessful(): BuildResult {
+    assertThat(output).contains("BUILD SUCCESSFUL")
+    return this
+}
+
+/**
+ * Resolves the generated `BuildKonfig.kt` (or [objectName]`.kt`) for a given
+ * [sourceSetName] and [packageName] under [buildKonfigDir].
+ */
+fun buildKonfigFile(
+    buildKonfigDir: File,
+    sourceSetName: String,
+    packageName: String,
+    objectName: String = "BuildKonfig",
+): File = File(
+    buildKonfigDir,
+    "$sourceSetName/${packageName.replace('.', '/')}/$objectName.kt",
+)
 
 val androidManifest = """
         |<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
## Summary

Closes #300.

Introduces shared test scaffolding so individual Gradle plugin test classes can focus on the DSL under test rather than the plumbing around it.

- New helpers in `TestUtils.kt`:
  - `gradleRunner(projectDir)` — `GradleRunner.create().withProjectDir(...).withPluginClasspath()`
  - `TemporaryFolder.buildKonfigDir()` — returns a freshly cleaned `build/buildkonfig`
  - `BuildResult.assertBuildSuccessful()` — chainable `BUILD SUCCESSFUL` assertion
  - `buildKonfigFile(buildDir, sourceSet, packageName, objectName)` — resolves generated files
- New `BaseGradlePluginTest` abstract class:
  - `@get:Rule TemporaryFolder` and `buildFile` / `settingFile` fields
  - Shared `@Before` setup that writes `settings.gradle`
  - `buildFileName` override hook for Kotlin DSL (`build.gradle.kts`)
  - `extraSetup()` hook for `gradle.properties` and other fixtures
- Migrated all 9 test classes to extend `BaseGradlePluginTest` and use the new helpers.

### Numbers

- 9 test classes migrated, ~570-line net reduction (445 insertions vs 1013 deletions in the test sources)
- `GradleRunner.create().withProjectDir(...).withPluginClasspath()` chains: 38 inlined → 1 (in `TestUtils`)
- `File(projectDir.root, "build/buildkonfig").also { it.deleteRecursively() }` blocks: 34 inlined → 1
- `assertThat(result.output).contains("BUILD SUCCESSFUL")`: 32 inlined → 1
- `@Before fun setup()` boilerplate (9 classes) → centralized in the base class

## Test plan

- [x] `./gradlew :buildkonfig-gradle-plugin:test --rerun-tasks` passes locally (58s)
- [x] No remaining inlined `GradleRunner.create()`, `File(projectDir.root, "build/buildkonfig")`, or `BUILD SUCCESSFUL` assertion outside `TestUtils.kt`
- [x] No behavior change in any test — pure deduplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)