### PR TITLE
test: add unit tests for the compiler module and the merge-logic helpers

### DIFF
--- a/buildkonfig-compiler/build.gradle.kts
+++ b/buildkonfig-compiler/build.gradle.kts
@@ -19,6 +19,9 @@ tasks.named<Delete>("clean") {
 
 dependencies {
     implementation(libs.kotlinpoet)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
 }
 
 tasks.register("pluginVersion") {

--- a/buildkonfig-compiler/src/test/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironmentTest.kt
+++ b/buildkonfig-compiler/src/test/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironmentTest.kt
@@ -1,0 +1,245 @@
+package com.codingfeline.buildkonfig.compiler
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class BuildKonfigEnvironmentTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun `single concrete object is generated when no target configs are present`() {
+        val outputDir = tempFolder.newFolder("commonMain")
+        val data = BuildKonfigData(
+            packageName = "com.example",
+            objectName = "BuildKonfig",
+            exposeObject = false,
+            commonConfig = configFile(
+                name = COMMON_SOURCESET_NAME,
+                platformType = PlatformType.common,
+                outputDirectory = outputDir,
+                fields = listOf(stringField("foo", "bar")),
+            ),
+            targetConfigs = emptyList(),
+            hasJsTarget = false,
+        )
+
+        val logger = RecordingLogger()
+        val status = BuildKonfigEnvironment(data).generateConfigs(logger)
+
+        assertThat(status).isInstanceOf(BuildKonfigEnvironment.CompilationStatus.Success::class.java)
+
+        val generated = File(outputDir, "com/example/BuildKonfig.kt")
+        assertThat(generated.exists()).isTrue()
+
+        val content = generated.readText()
+        assertThat(content).contains("internal object BuildKonfig")
+        assertThat(content).contains("public val foo: String = \"bar\"")
+        assertThat(content).doesNotContain("expect ")
+        assertThat(content).doesNotContain("actual ")
+    }
+
+    @Test
+    fun `expect-actual pair is generated when target configs are present`() {
+        val commonDir = tempFolder.newFolder("commonMain")
+        val jvmDir = tempFolder.newFolder("jvmMain")
+
+        val data = BuildKonfigData(
+            packageName = "com.example",
+            objectName = "BuildKonfig",
+            exposeObject = false,
+            commonConfig = configFile(
+                name = COMMON_SOURCESET_NAME,
+                platformType = PlatformType.common,
+                outputDirectory = commonDir,
+                fields = listOf(stringField("env", "default")),
+            ),
+            targetConfigs = listOf(
+                configFile(
+                    name = "jvmMain",
+                    platformType = PlatformType.jvm,
+                    outputDirectory = jvmDir,
+                    fields = listOf(stringField("env", "jvm")),
+                ),
+            ),
+            hasJsTarget = false,
+        )
+
+        val status = BuildKonfigEnvironment(data).generateConfigs(RecordingLogger())
+        assertThat(status).isInstanceOf(BuildKonfigEnvironment.CompilationStatus.Success::class.java)
+
+        val commonFile = File(commonDir, "com/example/BuildKonfig.kt")
+        assertThat(commonFile.readText()).apply {
+            contains("internal expect object BuildKonfig")
+            contains("public val env: String")
+            doesNotContain("actual ")
+        }
+
+        val jvmFile = File(jvmDir, "com/example/BuildKonfig.kt")
+        assertThat(jvmFile.readText()).apply {
+            contains("internal actual object BuildKonfig")
+            contains("actual val env: String = \"jvm\"")
+            doesNotContain("expect ")
+        }
+    }
+
+    @Test
+    fun `nullable and const fields are emitted with the right modifiers`() {
+        val outputDir = tempFolder.newFolder("commonMain")
+        val data = BuildKonfigData(
+            packageName = "com.example",
+            objectName = "BuildKonfig",
+            exposeObject = false,
+            commonConfig = configFile(
+                name = COMMON_SOURCESET_NAME,
+                platformType = PlatformType.common,
+                outputDirectory = outputDir,
+                fields = listOf(
+                    FieldSpec(FieldSpec.Type.STRING, "nullableString", null, nullable = true),
+                    FieldSpec(FieldSpec.Type.STRING, "constString", "value", const = true),
+                    FieldSpec(FieldSpec.Type.INT, "regularInt", "42"),
+                ),
+            ),
+            targetConfigs = emptyList(),
+            hasJsTarget = false,
+        )
+
+        BuildKonfigEnvironment(data).generateConfigs(RecordingLogger())
+
+        val content = File(outputDir, "com/example/BuildKonfig.kt").readText()
+        assertThat(content).contains("public val nullableString: String? = null")
+        assertThat(content).contains("public const val constString: String = \"value\"")
+        assertThat(content).contains("public val regularInt: Int = 42")
+    }
+
+    @Test
+    fun `exposeObjectWithName plus a JS target adds @JsExport`() {
+        val outputDir = tempFolder.newFolder("commonMain")
+        val data = BuildKonfigData(
+            packageName = "com.example",
+            objectName = "BuildKonfig",
+            exposeObject = true,
+            commonConfig = configFile(
+                name = COMMON_SOURCESET_NAME,
+                platformType = PlatformType.common,
+                outputDirectory = outputDir,
+                fields = listOf(stringField("foo", "bar")),
+            ),
+            targetConfigs = emptyList(),
+            hasJsTarget = true,
+        )
+
+        BuildKonfigEnvironment(data).generateConfigs(RecordingLogger())
+
+        val content = File(outputDir, "com/example/BuildKonfig.kt").readText()
+        assertThat(content).contains("@JsExport")
+        assertThat(content).contains("@OptIn(ExperimentalJsExport::class)")
+        assertThat(content).contains("public object BuildKonfig")
+    }
+
+    @Test
+    fun `exposeObjectWithName without a JS target does not add @JsExport`() {
+        val outputDir = tempFolder.newFolder("commonMain")
+        val data = BuildKonfigData(
+            packageName = "com.example",
+            objectName = "BuildKonfig",
+            exposeObject = true,
+            commonConfig = configFile(
+                name = COMMON_SOURCESET_NAME,
+                platformType = PlatformType.common,
+                outputDirectory = outputDir,
+                fields = listOf(stringField("foo", "bar")),
+            ),
+            targetConfigs = emptyList(),
+            hasJsTarget = false,
+        )
+
+        BuildKonfigEnvironment(data).generateConfigs(RecordingLogger())
+
+        val content = File(outputDir, "com/example/BuildKonfig.kt").readText()
+        assertThat(content).doesNotContain("@JsExport")
+        assertThat(content).doesNotContain("@OptIn(ExperimentalJsExport::class)")
+        assertThat(content).contains("public object BuildKonfig")
+    }
+
+    @Test
+    fun `const fields warn when target-specific configs are present (K2 limitation)`() {
+        val commonDir = tempFolder.newFolder("commonMain")
+        val jvmDir = tempFolder.newFolder("jvmMain")
+
+        val data = BuildKonfigData(
+            packageName = "com.example",
+            objectName = "BuildKonfig",
+            exposeObject = false,
+            commonConfig = configFile(
+                name = COMMON_SOURCESET_NAME,
+                platformType = PlatformType.common,
+                outputDirectory = commonDir,
+                fields = listOf(
+                    FieldSpec(FieldSpec.Type.STRING, "constField", "value", const = true),
+                ),
+            ),
+            targetConfigs = listOf(
+                configFile(
+                    name = "jvmMain",
+                    platformType = PlatformType.jvm,
+                    outputDirectory = jvmDir,
+                    fields = listOf(stringField("env", "jvm")),
+                ),
+            ),
+            hasJsTarget = false,
+        )
+
+        val logger = RecordingLogger()
+        BuildKonfigEnvironment(data).generateConfigs(logger)
+
+        val warnings = logger.messages.filter { it.first == LogLevel.WARN }.map { it.second }
+        assertThat(warnings).isNotEmpty()
+        assertThat(warnings.first()).contains("[constField]")
+        assertThat(warnings.first()).contains("declared with `const = true`")
+
+        // Common file emits `val` (not `const val`) due to the K2 expect-side restriction;
+        // each target keeps `actual const val`.
+        val commonContent = File(commonDir, "com/example/BuildKonfig.kt").readText()
+        assertThat(commonContent).contains("public val constField: String")
+        assertThat(commonContent).doesNotContain("const val constField")
+    }
+
+    private companion object {
+
+        const val COMMON_SOURCESET_NAME = "commonMain"
+
+        fun stringField(name: String, value: String): FieldSpec =
+            FieldSpec(FieldSpec.Type.STRING, name, value)
+
+        fun configFile(
+            name: String,
+            platformType: PlatformType,
+            outputDirectory: File,
+            fields: List<FieldSpec>,
+        ): TargetConfigFile = TestTargetConfigFile(
+            targetName = TargetName(name, platformType),
+            outputDirectory = outputDirectory,
+            config = TargetConfig(name).apply {
+                fields.forEach { fieldSpecs[it.name] = it }
+            },
+        )
+
+        private data class TestTargetConfigFile(
+            override val targetName: TargetName,
+            override val outputDirectory: File,
+            override val config: TargetConfig?,
+        ) : TargetConfigFile
+
+        class RecordingLogger : BuildKonfigLogger {
+            val messages = mutableListOf<Pair<LogLevel, String>>()
+            override fun log(level: LogLevel, message: String) {
+                messages.add(level to message)
+            }
+        }
+    }
+}

--- a/buildkonfig-compiler/src/test/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironmentTest.kt
+++ b/buildkonfig-compiler/src/test/kotlin/com/codingfeline/buildkonfig/compiler/BuildKonfigEnvironmentTest.kt
@@ -14,29 +14,20 @@ class BuildKonfigEnvironmentTest {
     @Test
     fun `single concrete object is generated when no target configs are present`() {
         val outputDir = tempFolder.newFolder("commonMain")
-        val data = BuildKonfigData(
-            packageName = "com.example",
-            objectName = "BuildKonfig",
-            exposeObject = false,
+        val data = buildData(
             commonConfig = configFile(
                 name = COMMON_SOURCESET_NAME,
                 platformType = PlatformType.common,
                 outputDirectory = outputDir,
                 fields = listOf(stringField("foo", "bar")),
             ),
-            targetConfigs = emptyList(),
-            hasJsTarget = false,
         )
 
-        val logger = RecordingLogger()
-        val status = BuildKonfigEnvironment(data).generateConfigs(logger)
+        val status = BuildKonfigEnvironment(data).generateConfigs(RecordingLogger())
 
         assertThat(status).isInstanceOf(BuildKonfigEnvironment.CompilationStatus.Success::class.java)
 
-        val generated = File(outputDir, "com/example/BuildKonfig.kt")
-        assertThat(generated.exists()).isTrue()
-
-        val content = generated.readText()
+        val content = File(outputDir, "com/example/BuildKonfig.kt").readText()
         assertThat(content).contains("internal object BuildKonfig")
         assertThat(content).contains("public val foo: String = \"bar\"")
         assertThat(content).doesNotContain("expect ")
@@ -48,10 +39,7 @@ class BuildKonfigEnvironmentTest {
         val commonDir = tempFolder.newFolder("commonMain")
         val jvmDir = tempFolder.newFolder("jvmMain")
 
-        val data = BuildKonfigData(
-            packageName = "com.example",
-            objectName = "BuildKonfig",
-            exposeObject = false,
+        val data = buildData(
             commonConfig = configFile(
                 name = COMMON_SOURCESET_NAME,
                 platformType = PlatformType.common,
@@ -66,7 +54,6 @@ class BuildKonfigEnvironmentTest {
                     fields = listOf(stringField("env", "jvm")),
                 ),
             ),
-            hasJsTarget = false,
         )
 
         val status = BuildKonfigEnvironment(data).generateConfigs(RecordingLogger())
@@ -90,10 +77,7 @@ class BuildKonfigEnvironmentTest {
     @Test
     fun `nullable and const fields are emitted with the right modifiers`() {
         val outputDir = tempFolder.newFolder("commonMain")
-        val data = BuildKonfigData(
-            packageName = "com.example",
-            objectName = "BuildKonfig",
-            exposeObject = false,
+        val data = buildData(
             commonConfig = configFile(
                 name = COMMON_SOURCESET_NAME,
                 platformType = PlatformType.common,
@@ -104,8 +88,6 @@ class BuildKonfigEnvironmentTest {
                     FieldSpec(FieldSpec.Type.INT, "regularInt", "42"),
                 ),
             ),
-            targetConfigs = emptyList(),
-            hasJsTarget = false,
         )
 
         BuildKonfigEnvironment(data).generateConfigs(RecordingLogger())
@@ -119,17 +101,14 @@ class BuildKonfigEnvironmentTest {
     @Test
     fun `exposeObjectWithName plus a JS target adds @JsExport`() {
         val outputDir = tempFolder.newFolder("commonMain")
-        val data = BuildKonfigData(
-            packageName = "com.example",
-            objectName = "BuildKonfig",
-            exposeObject = true,
+        val data = buildData(
             commonConfig = configFile(
                 name = COMMON_SOURCESET_NAME,
                 platformType = PlatformType.common,
                 outputDirectory = outputDir,
                 fields = listOf(stringField("foo", "bar")),
             ),
-            targetConfigs = emptyList(),
+            exposeObject = true,
             hasJsTarget = true,
         )
 
@@ -144,18 +123,14 @@ class BuildKonfigEnvironmentTest {
     @Test
     fun `exposeObjectWithName without a JS target does not add @JsExport`() {
         val outputDir = tempFolder.newFolder("commonMain")
-        val data = BuildKonfigData(
-            packageName = "com.example",
-            objectName = "BuildKonfig",
-            exposeObject = true,
+        val data = buildData(
             commonConfig = configFile(
                 name = COMMON_SOURCESET_NAME,
                 platformType = PlatformType.common,
                 outputDirectory = outputDir,
                 fields = listOf(stringField("foo", "bar")),
             ),
-            targetConfigs = emptyList(),
-            hasJsTarget = false,
+            exposeObject = true,
         )
 
         BuildKonfigEnvironment(data).generateConfigs(RecordingLogger())
@@ -171,10 +146,7 @@ class BuildKonfigEnvironmentTest {
         val commonDir = tempFolder.newFolder("commonMain")
         val jvmDir = tempFolder.newFolder("jvmMain")
 
-        val data = BuildKonfigData(
-            packageName = "com.example",
-            objectName = "BuildKonfig",
-            exposeObject = false,
+        val data = buildData(
             commonConfig = configFile(
                 name = COMMON_SOURCESET_NAME,
                 platformType = PlatformType.common,
@@ -191,7 +163,6 @@ class BuildKonfigEnvironmentTest {
                     fields = listOf(stringField("env", "jvm")),
                 ),
             ),
-            hasJsTarget = false,
         )
 
         val logger = RecordingLogger()
@@ -215,6 +186,22 @@ class BuildKonfigEnvironmentTest {
 
         fun stringField(name: String, value: String): FieldSpec =
             FieldSpec(FieldSpec.Type.STRING, name, value)
+
+        fun buildData(
+            commonConfig: TargetConfigFile,
+            targetConfigs: List<TargetConfigFile> = emptyList(),
+            exposeObject: Boolean = false,
+            hasJsTarget: Boolean = false,
+            packageName: String = "com.example",
+            objectName: String = "BuildKonfig",
+        ): BuildKonfigData = BuildKonfigData(
+            packageName = packageName,
+            objectName = objectName,
+            exposeObject = exposeObject,
+            commonConfig = commonConfig,
+            targetConfigs = targetConfigs,
+            hasJsTarget = hasJsTarget,
+        )
 
         fun configFile(
             name: String,

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpecTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpecTest.kt
@@ -1,0 +1,169 @@
+package com.codingfeline.buildkonfig.gradle
+
+import com.codingfeline.buildkonfig.compiler.BuildKonfigLogger
+import com.codingfeline.buildkonfig.compiler.FieldSpec
+import com.codingfeline.buildkonfig.compiler.LogLevel
+import com.codingfeline.buildkonfig.compiler.TargetConfig
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BuildKonfigSpecTest {
+
+    @Test
+    fun `mergeConfigs - non-colliding fields are unioned and onReplaced is not invoked`() {
+        val base = targetConfig("common", stringField("a", "1"))
+        val new = targetConfig("common", stringField("b", "2"))
+        val replaced = mutableListOf<Pair<FieldSpec, FieldSpec>>()
+
+        val result = mergeConfigs(base, new) { old, n -> replaced += old to n }
+
+        assertThat(result.fieldSpecs.keys).containsExactly("a", "b")
+        assertThat(result.fieldSpecs["a"]?.value).isEqualTo("1")
+        assertThat(result.fieldSpecs["b"]?.value).isEqualTo("2")
+        assertThat(replaced).isEmpty()
+    }
+
+    @Test
+    fun `mergeConfigs - new field overrides base on collision and onReplaced is invoked`() {
+        val base = targetConfig("common", stringField("key", "base"))
+        val new = targetConfig("common", stringField("key", "new"))
+        val replaced = mutableListOf<Pair<FieldSpec, FieldSpec>>()
+
+        val result = mergeConfigs(base, new) { old, n -> replaced += old to n }
+
+        assertThat(result.fieldSpecs["key"]?.value).isEqualTo("new")
+        assertThat(replaced).hasSize(1)
+        assertThat(replaced.single().first.value).isEqualTo("base")
+        assertThat(replaced.single().second.value).isEqualTo("new")
+    }
+
+    @Test
+    fun `mergeDefaultConfigs - returns default copy when flavor is DEFAULT_FLAVOR`() {
+        val defaults = mapOf(DEFAULT_FLAVOR to targetConfig("defaults", stringField("a", "1")))
+        val logger = RecordingLogger()
+
+        val merged = mergeDefaultConfigs(logger, DEFAULT_FLAVOR, defaults)
+
+        assertThat(merged.fieldSpecs["a"]?.value).isEqualTo("1")
+        assertThat(logger.messages).isEmpty()
+    }
+
+    @Test
+    fun `mergeDefaultConfigs - returns default copy when flavor has no entry`() {
+        val defaults = mapOf(DEFAULT_FLAVOR to targetConfig("defaults", stringField("a", "1")))
+        val logger = RecordingLogger()
+
+        val merged = mergeDefaultConfigs(logger, "nonexistent", defaults)
+
+        assertThat(merged.fieldSpecs["a"]?.value).isEqualTo("1")
+        assertThat(logger.messages).isEmpty()
+    }
+
+    @Test
+    fun `mergeDefaultConfigs - flavored defaults override unflavored on collision and log info`() {
+        val defaults = mapOf(
+            DEFAULT_FLAVOR to targetConfig("defaults", stringField("env", "prod")),
+            "dev" to targetConfig("defaults", stringField("env", "dev")),
+        )
+        val logger = RecordingLogger()
+
+        val merged = mergeDefaultConfigs(logger, "dev", defaults)
+
+        assertThat(merged.fieldSpecs["env"]?.value).isEqualTo("dev")
+        val info = logger.messages.filter { it.first == LogLevel.INFO }.map { it.second }
+        assertThat(info).isNotEmpty()
+        assertThat(info.first()).contains("BuildKonfig(Default)")
+        assertThat(info.first()).contains("env")
+        assertThat(info.first()).contains("flavored(dev)")
+    }
+
+    @Test
+    fun `mergeTargetConfigs - keys results by sourceSet name`() {
+        val targets = mapOf(
+            DEFAULT_FLAVOR to listOf(
+                targetConfig("jvm", stringField("a", "1")),
+                targetConfig("iosX64", stringField("b", "2")),
+            ),
+        )
+        val logger = RecordingLogger()
+
+        val merged = mergeTargetConfigs(logger, DEFAULT_FLAVOR, targets)
+
+        assertThat(merged.keys).containsExactly("jvmMain", "iosX64Main")
+        assertThat(merged["jvmMain"]?.fieldSpecs?.get("a")?.value).isEqualTo("1")
+        assertThat(merged["iosX64Main"]?.fieldSpecs?.get("b")?.value).isEqualTo("2")
+    }
+
+    @Test
+    fun `mergeTargetConfigs - flavored target overrides non-flavored on collision and log info`() {
+        val targets = mapOf(
+            DEFAULT_FLAVOR to listOf(targetConfig("jvm", stringField("env", "default"))),
+            "dev" to listOf(targetConfig("jvm", stringField("env", "dev"))),
+        )
+        val logger = RecordingLogger()
+
+        val merged = mergeTargetConfigs(logger, "dev", targets)
+
+        assertThat(merged["jvmMain"]?.fieldSpecs?.get("env")?.value).isEqualTo("dev")
+        val info = logger.messages.filter { it.first == LogLevel.INFO }.map { it.second }
+        assertThat(info).isNotEmpty()
+        assertThat(info.first()).contains("BuildKonfig(jvmMain)")
+        assertThat(info.first()).contains("flavored(dev)")
+    }
+
+    @Test
+    fun `mergeTargetConfigs - flavor with no entry returns only the default targets`() {
+        val targets = mapOf(
+            DEFAULT_FLAVOR to listOf(targetConfig("jvm", stringField("env", "default"))),
+        )
+        val logger = RecordingLogger()
+
+        val merged = mergeTargetConfigs(logger, "nonexistent", targets)
+
+        assertThat(merged.keys).containsExactly("jvmMain")
+        assertThat(merged["jvmMain"]?.fieldSpecs?.get("env")?.value).isEqualTo("default")
+    }
+
+    @Test
+    fun `checkTargetSpecificFields - fields absent from default are marked target-specific`() {
+        val default = targetConfig("defaults", stringField("shared", "x"))
+        val target = targetConfig(
+            "jvm",
+            stringField("shared", "x"),
+            stringField("jvmOnly", "y"),
+        )
+
+        val checked = checkTargetSpecificFields(default, target)
+
+        assertThat(checked.fieldSpecs["shared"]?.isTargetSpecific).isFalse()
+        assertThat(checked.fieldSpecs["jvmOnly"]?.isTargetSpecific).isTrue()
+    }
+
+    @Test
+    fun `checkTargetSpecificFields - empty default config marks every target field as target-specific`() {
+        val default = targetConfig("defaults")
+        val target = targetConfig("jvm", stringField("a", "1"), stringField("b", "2"))
+
+        val checked = checkTargetSpecificFields(default, target)
+
+        assertThat(checked.fieldSpecs.values.all { it.isTargetSpecific }).isTrue()
+    }
+
+    private companion object {
+
+        fun stringField(name: String, value: String?): FieldSpec =
+            FieldSpec(FieldSpec.Type.STRING, name, value)
+
+        fun targetConfig(name: String, vararg fields: FieldSpec): TargetConfig =
+            TargetConfig(name).also { config ->
+                fields.forEach { config.fieldSpecs[it.name] = it }
+            }
+
+        class RecordingLogger : BuildKonfigLogger {
+            val messages = mutableListOf<Pair<LogLevel, String>>()
+            override fun log(level: LogLevel, message: String) {
+                messages.add(level to message)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #299.

Adds direct unit tests for two pieces of pure logic that were previously only verified end-to-end through Gradle TestKit fixtures.

### `buildkonfig-compiler` (new test root)

Stands up a JUnit 4 + Truth setup in the compiler module and adds `BuildKonfigEnvironmentTest` covering `generateConfigs`:

- Single concrete object when no target configs are present.
- `expect`/`actual` pair when target configs are present.
- Nullable and `const` field modifier handling.
- `@JsExport` emitted for `exposeObject = true` only when a JS target exists.
- The K2 `const`-on-expect warning fires and the common file emits `val` rather than `const val`.

The test uses a `TemporaryFolder` for the `FileAppender` output directory and reads the generated Kotlin sources back to assert on content. Anonymous `TargetConfigFile` and `BuildKonfigLogger` implementations live as test helpers — no production code refactor required.

### `buildkonfig-gradle-plugin` — merge-logic tests

Adds `BuildKonfigSpecTest` covering the pure helpers directly:

- `mergeConfigs`: union vs override behavior; `onReplaced` callback fires with old/new specs on field collisions.
- `mergeDefaultConfigs`: identity for `DEFAULT_FLAVOR` / unknown flavor; flavored defaults override unflavored on collision and log `info`.
- `mergeTargetConfigs`: result keyed by `<sourceSet>Main`; flavored targets override on collision; missing flavor returns the default set.
- `checkTargetSpecificFields`: marks fields absent from default as `isTargetSpecific = true`.

The "missing `defaultConfigs` returns `null` and warns" path noted in the issue is the top-level `BuildKonfigExtension.mergeConfigs` extension, which requires a Gradle `ObjectFactory` to instantiate — that path stays covered by the existing TestKit assertion in `BuildKonfigPluginTest.\`buildkonfig block without defaultConfigs warns and skips\``.

### Numbers

- Compiler module: 0 → 6 tests (new test root)
- Plugin module merge-logic tests: 0 → 10 tests (new file)
- Plus the pre-existing 43 TestKit tests, all still green.

## Test plan

- [x] `./gradlew test --rerun-tasks` passes locally — 59 tests across both modules
- [x] Each new test exercises the targeted code path (sanity-checked by mutating the production code and seeing the test fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)