### PR TITLE
refactor(plugin): make BuildKonfigTask cacheable via a single @OutputDirectory

### DIFF
--- a/.claude/rules/gradle.md
+++ b/.claude/rules/gradle.md
@@ -1,0 +1,17 @@
+## Gradle conventions
+
+Applies to Gradle plugin sources under `buildkonfig-gradle-plugin/src/main/**/*.kt`.
+
+### Task-output Providers cannot be queried at configuration time
+
+Gradle 7+ rejects `.get()` on a Provider chain that resolves through a `TaskProvider`'s output before the task has run, with:
+
+> Querying the mapped value of flatmap(provider(task '...', class ...)) before task ':...' has completed is not supported.
+
+Don't try to source a "single source of truth" for paths from `task.flatMap { it.outputDirectory }` if any consumer eagerly resolves it (e.g. `provider.map { ... }.get().asFile` at config time). Instead:
+
+- Compute the rooted `Provider<Directory>` once from `project.layout.buildDirectory.dir(...)`.
+- Wire it into the task via `task.outputDirectory.set(rootedProvider)`.
+- Reuse the same `rootedProvider` for any config-time eager resolution downstream.
+
+Lazy chains (e.g. `kotlinSourceSet.kotlin.srcDir(task.flatMap { it.outputDirectory.dir(name) })`) are fine because Gradle resolves them at task execution.

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -26,6 +26,8 @@ const val DEFAULT_FLAVOR: Flavor = ""
 const val COMMON_SOURCESET_NAME = "commonMain"
 const val MAIN_SOURCESET_NAME = "main"
 
+private const val OUTPUT_DIR_NAME = "buildkonfig"
+
 @Suppress("unused")
 abstract class BuildKonfigPlugin : Plugin<Project> {
 
@@ -53,6 +55,8 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
     }
 
     private fun configure(project: Project, extension: BuildKonfigExtension) {
+        val outputDirectory = project.layout.buildDirectory.dir(OUTPUT_DIR_NAME)
+
         // Register the task eagerly (outside afterEvaluate) so its outputs participate in
         // Gradle's task graph as Providers from the start. This is what allows downstream
         // tasks (e.g. KSP under Gradle 9.0) to discover an implicit dependency edge through
@@ -60,6 +64,8 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         val task = project.tasks.register("generateBuildKonfig", BuildKonfigTask::class.java) {
             it.group = "buildkonfig"
             it.description = "generate BuildKonfig"
+
+            it.outputDirectory.set(outputDirectory)
 
             // Wire singleton DSL fields as Provider-to-Provider so the values are read lazily
             // at task execution time. Required inputs (e.g. packageName) surface as native
@@ -81,9 +87,9 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         project.afterEvaluate {
             val kmpExtension = project.extensions.findByType(KotlinMultiplatformExtension::class.java)
             if (kmpExtension != null) {
-                configureMultiplatform(project, extension, task, kmpExtension)
+                configureMultiplatform(project, extension, task, kmpExtension, outputDirectory)
             } else {
-                configureSinglePlatform(project, extension, task)
+                configureSinglePlatform(project, extension, task, outputDirectory)
             }
         }
     }
@@ -93,9 +99,8 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         extension: BuildKonfigExtension,
         task: TaskProvider<BuildKonfigTask>,
         kmpExtension: KotlinMultiplatformExtension,
+        outputDirectory: Provider<Directory>,
     ) {
-        val outputDirectory = project.layout.buildDirectory.dir("buildkonfig")
-
         val flavor = project.findFlavor()
 
         val mergedConfigs = extension.mergeConfigs(project.logger.toBuildKonfigLogger(), flavor)
@@ -120,8 +125,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         }
 
         targetConfigSources.forEach { (key, configSource) ->
-            val outputDirs = task.map { t -> listOfNotNull(t.outputDirectories[key]) }
-            configSource.registerSourceDir(outputDirs)
+            configSource.registerSourceDir(task.flatMap { it.outputDirectory.dir(key) })
         }
     }
 
@@ -129,6 +133,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         project: Project,
         extension: BuildKonfigExtension,
         task: TaskProvider<BuildKonfigTask>,
+        outputDirectory: Provider<Directory>,
     ) {
         val kotlinExtension = project.extensions.findByType(KotlinProjectExtension::class.java) ?: return
 
@@ -162,7 +167,6 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         // target-specific entries (the user was already warned) so the task generates a
         // single concrete object rather than an expect/actual pair.
         val mainConfig = mergedConfigs.getValue(MAIN_SOURCESET_NAME)
-        val outputDirectory = project.layout.buildDirectory.dir("buildkonfig")
         val targetConfigFile = TargetConfigFileImpl(
             targetName = TargetName(MAIN_SOURCESET_NAME, platformType.toPlatformType()),
             outputDirectory = outputDirectory.subdirAsFile(MAIN_SOURCESET_NAME),
@@ -177,8 +181,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         }
 
         val mainSourceSet = kotlinExtension.sourceSets.getByName(MAIN_SOURCESET_NAME)
-        val outputDirs = task.map { t -> listOfNotNull(t.outputDirectories[MAIN_SOURCESET_NAME]) }
-        mainSourceSet.kotlin.srcDirs(outputDirs)
+        mainSourceSet.kotlin.srcDir(task.flatMap { it.outputDirectory.dir(MAIN_SOURCESET_NAME) })
     }
 }
 
@@ -225,7 +228,7 @@ fun decideOutputs(
                         outputDirectory = outputDirectory.subdirAsFile(firstDependent.name),
                         config = targetConfigs.getValue(firstDependent.name)
                     ),
-                    registerSourceDir = { dir -> firstDependent.kotlin.srcDirs(dir) }
+                    registerSourceDir = { dir -> firstDependent.kotlin.srcDir(dir) }
                 )
 
                 return@fold acc + (firstDependent.name to tcs)
@@ -248,7 +251,7 @@ fun decideOutputs(
                     outputDirectory = outputDirectory.subdirAsFile(targetSourceSet.name),
                     config = targetConfigs[source.name] ?: targetConfigs.getValue(COMMON_SOURCESET_NAME).copy(),
                 ),
-                registerSourceDir = { dir -> targetSourceSet.kotlin.srcDirs(dir) }
+                registerSourceDir = { dir -> targetSourceSet.kotlin.srcDir(dir) }
             )
 
             acc + (source.name to tcs)

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpec.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpec.kt
@@ -5,6 +5,7 @@ import com.codingfeline.buildkonfig.compiler.FieldSpec
 import com.codingfeline.buildkonfig.compiler.TargetConfig
 import com.codingfeline.buildkonfig.compiler.TargetConfigFile
 import com.codingfeline.buildkonfig.compiler.TargetName
+import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -19,7 +20,7 @@ data class TargetConfigSource(
      * underlying source set comes from a KMP target, a standalone Kotlin/JVM project,
      * a standalone Kotlin/JS project, etc.
      */
-    val registerSourceDir: (Provider<List<File>>) -> Unit,
+    val registerSourceDir: (Provider<Directory>) -> Unit,
 )
 
 data class TargetConfigFileImpl(

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
@@ -4,18 +4,18 @@ import com.codingfeline.buildkonfig.VERSION
 import com.codingfeline.buildkonfig.compiler.BuildKonfigData
 import com.codingfeline.buildkonfig.compiler.BuildKonfigEnvironment
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.OutputDirectories
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.work.DisableCachingByDefault
-import java.io.File
 
 const val FLAVOR_PROPERTY = "buildkonfig.flavor"
 
-@DisableCachingByDefault(because = "BuildKonfig generation is fast enough that caching adds little value")
+@CacheableTask
 abstract class BuildKonfigTask : DefaultTask() {
 
     // Required to invalidate the task on version updates.
@@ -50,20 +50,25 @@ abstract class BuildKonfigTask : DefaultTask() {
     @get:Nested
     abstract val targetConfigFiles: MapProperty<String, TargetConfigFileImpl>
 
-    @Suppress("unused")
-    @get:OutputDirectories
-    val outputDirectories: Map<String, File>
-        get() = targetConfigFiles.get().mapValues { it.value.outputDirectory }
+    /**
+     * Root directory containing all generated BuildKonfig sources, with one subdirectory
+     * per source set (e.g. `build/buildkonfig/commonMain`, `build/buildkonfig/jvmMain`).
+     * Declared as a single `@OutputDirectory` so the entire subtree participates in the
+     * cache key / restore cycle, and stale subdirectories from removed source sets
+     * cannot leak through.
+     */
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
 
     @Suppress("unused")
     @TaskAction
     fun generateBuildKonfigFiles() {
-        val commonName = commonSourceSetName.get()
-        val outputDirs = outputDirectories
-        // clean up output directories
-        outputDirs.getValue(commonName).parentFile.cleanupDirectory()
-        outputDirs.forEach { it.value.mkdirs() }
+        // Gradle does not auto-clean `@OutputDirectory` content for ad-hoc tasks, so we
+        // wipe the root explicitly. On cache hits the action does not run and Gradle
+        // performs the cleanup + restore itself.
+        outputDirectory.get().asFile.deleteRecursively()
 
+        val commonName = commonSourceSetName.get()
         val configFiles = targetConfigFiles.get()
         val data = BuildKonfigData(
             packageName = packageName.get(),
@@ -75,10 +80,5 @@ abstract class BuildKonfigTask : DefaultTask() {
         )
 
         BuildKonfigEnvironment(data).generateConfigs(logger.toBuildKonfigLogger())
-    }
-
-    private fun File.cleanupDirectory() {
-        deleteRecursively()
-        mkdirs()
     }
 }

--- a/sample-kts/src/commonMain/kotlin/com/codingfeline/buildkonfigsample/AppInfo.kt
+++ b/sample-kts/src/commonMain/kotlin/com/codingfeline/buildkonfigsample/AppInfo.kt
@@ -1,0 +1,11 @@
+package com.codingfeline.buildkonfigsample
+
+object AppInfo {
+    val summary: String = buildString {
+        append("test=").append(BuildKonfig.test)
+        append(", target=").append(BuildKonfig.target)
+        append(", testKey1=").append(BuildKonfig.testKey1)
+        append(", testKey2=").append(BuildKonfig.testKey2)
+        append(", testKey3=").append(BuildKonfig.testKey3)
+    }
+}

--- a/sample-kts/src/desktopMain/kotlin/com/codingfeline/buildkonfigsample/DesktopInfo.kt
+++ b/sample-kts/src/desktopMain/kotlin/com/codingfeline/buildkonfigsample/DesktopInfo.kt
@@ -1,0 +1,5 @@
+package com.codingfeline.buildkonfigsample
+
+object DesktopInfo {
+    val desktopValue: String = BuildKonfig.desktopvalue
+}

--- a/sample/src/commonMain/kotlin/com/codingfeline/buildkonfigsample/AppInfo.kt
+++ b/sample/src/commonMain/kotlin/com/codingfeline/buildkonfigsample/AppInfo.kt
@@ -1,0 +1,11 @@
+package com.codingfeline.buildkonfigsample
+
+object AppInfo {
+    val summary: String = buildString {
+        append("test=").append(BuildKonfig.test)
+        append(", target=").append(BuildKonfig.target)
+        append(", testKey1=").append(BuildKonfig.testKey1)
+        append(", testKey2=").append(BuildKonfig.testKey2)
+        append(", testKey3=").append(BuildKonfig.testKey3)
+    }
+}

--- a/sample/src/desktopMain/kotlin/com/codingfeline/buildkonfigsample/DesktopInfo.kt
+++ b/sample/src/desktopMain/kotlin/com/codingfeline/buildkonfigsample/DesktopInfo.kt
@@ -1,0 +1,5 @@
+package com.codingfeline.buildkonfigsample
+
+object DesktopInfo {
+    val desktopValue: String = BuildKonfig.desktopvalue
+}


### PR DESCRIPTION
## Summary

Resolves #307. `BuildKonfigTask` now declares one rooted `@OutputDirectory` (`build/buildkonfig/`) instead of a per-target `@OutputDirectories` map, so:

- Gradle owns the output snapshot for caching, and stale subdirectories from removed source sets cannot leak through (the parent is now part of the declared output set).
- The `parentFile.cleanupDirectory()` hack — which used to wipe a *not-declared-as-output* parent — drops out, replaced by a `deleteRecursively()` of the declared output at task action start (mirrors `SqlDelightTask`'s pattern, since `@OutputDirectory` is not auto-cleaned for ad-hoc tasks).
- The task is now `@CacheableTask`. The `@DisableCachingByDefault` placeholder added in #306 is removed.

Source-set wiring for both KMP and single-platform now hands a `Provider<Directory>` (`task.flatMap { it.outputDirectory.dir(name) }`) to `kotlin.srcDir(...)`, so Gradle picks up both the source root and the implicit task dependency from a single argument. The `TargetConfigSource.registerSourceDir` callback signature changes accordingly from `(Provider<List<File>>) -> Unit` to `(Provider<Directory>) -> Unit`.

The `"buildkonfig"` directory literal is centralized as a private `OUTPUT_DIR_NAME` constant and the rooted `Provider<Directory>` is computed once in `configure()` and threaded into `configureMultiplatform` / `configureSinglePlatform` instead of being recomputed per call site.

### Out of scope

`TargetConfigFileImpl.outputDirectory: File` is still eagerly resolved at configuration time via `subdirAsFile` and threaded through the compiler module's `TargetConfigFile` interface. Unifying that with the task's `outputDirectory` provider would be a cross-module change to the `buildkonfig-compiler` API and is left for a follow-up.

## Test plan

- [x] `./gradlew clean build`
- [x] `./gradlew publishAllPublicationsToTestMavenRepository -PRELEASE_SIGNING_ENABLED=false`
- [x] `./gradlew -p sample generateBuildKonfig` (re-run UP-TO-DATE)
- [x] `./gradlew -p sample-kts generateBuildKonfig`

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)