### PR TITLE
refactor(plugin): derive per-target output directory at task action time

### DIFF
--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -9,10 +9,7 @@ import com.codingfeline.buildkonfig.compiler.TargetName
 import com.codingfeline.buildkonfig.gradle.kotlin.sources
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.file.Directory
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
-import java.io.File
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -55,8 +52,6 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
     }
 
     private fun configure(project: Project, extension: BuildKonfigExtension) {
-        val outputDirectory = project.layout.buildDirectory.dir(OUTPUT_DIR_NAME)
-
         // Register the task eagerly (outside afterEvaluate) so its outputs participate in
         // Gradle's task graph as Providers from the start. This is what allows downstream
         // tasks (e.g. KSP under Gradle 9.0) to discover an implicit dependency edge through
@@ -65,7 +60,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
             it.group = "buildkonfig"
             it.description = "generate BuildKonfig"
 
-            it.outputDirectory.set(outputDirectory)
+            it.outputDirectory.set(project.layout.buildDirectory.dir(OUTPUT_DIR_NAME))
 
             // Wire singleton DSL fields as Provider-to-Provider so the values are read lazily
             // at task execution time. Required inputs (e.g. packageName) surface as native
@@ -87,9 +82,9 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         project.afterEvaluate {
             val kmpExtension = project.extensions.findByType(KotlinMultiplatformExtension::class.java)
             if (kmpExtension != null) {
-                configureMultiplatform(project, extension, task, kmpExtension, outputDirectory)
+                configureMultiplatform(project, extension, task, kmpExtension)
             } else {
-                configureSinglePlatform(project, extension, task, outputDirectory)
+                configureSinglePlatform(project, extension, task)
             }
         }
     }
@@ -99,7 +94,6 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         extension: BuildKonfigExtension,
         task: TaskProvider<BuildKonfigTask>,
         kmpExtension: KotlinMultiplatformExtension,
-        outputDirectory: Provider<Directory>,
     ) {
         val flavor = project.findFlavor()
 
@@ -115,7 +109,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         val forceExpectActual = exposeObject && hasJsTarget && hasWasmTarget
 
         val targetConfigSources =
-            decideOutputs(project, kmpExtension, mergedConfigs, outputDirectory, forceExpectActual)
+            decideOutputs(project, kmpExtension, mergedConfigs, forceExpectActual)
 
         task.configure { t ->
             t.flavor.set(flavor)
@@ -133,7 +127,6 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         project: Project,
         extension: BuildKonfigExtension,
         task: TaskProvider<BuildKonfigTask>,
-        outputDirectory: Provider<Directory>,
     ) {
         val kotlinExtension = project.extensions.findByType(KotlinProjectExtension::class.java) ?: return
 
@@ -167,9 +160,8 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
         // target-specific entries (the user was already warned) so the task generates a
         // single concrete object rather than an expect/actual pair.
         val mainConfig = mergedConfigs.getValue(MAIN_SOURCESET_NAME)
-        val targetConfigFile = TargetConfigFileImpl(
+        val targetConfigFile = TargetConfigInput(
             targetName = TargetName(MAIN_SOURCESET_NAME, platformType.toPlatformType()),
-            outputDirectory = outputDirectory.subdirAsFile(MAIN_SOURCESET_NAME),
             config = mainConfig,
         )
 
@@ -189,7 +181,6 @@ fun decideOutputs(
     project: Project,
     kmpExtension: KotlinMultiplatformExtension,
     targetConfigs: Map<String, TargetConfig>,
-    outputDirectory: Provider<Directory>,
     forceExpectActual: Boolean = false
 ): Map<String, TargetConfigSource> {
     return kmpExtension.sources()
@@ -223,9 +214,8 @@ fun decideOutputs(
                 // if not available, create it.
                 val tcs = TargetConfigSource(
                     name = firstDependent.name,
-                    configFile = TargetConfigFileImpl(
+                    configFile = TargetConfigInput(
                         targetName = TargetName(firstDependent.name, source.type.toPlatformType()),
-                        outputDirectory = outputDirectory.subdirAsFile(firstDependent.name),
                         config = targetConfigs.getValue(firstDependent.name)
                     ),
                     registerSourceDir = { dir -> firstDependent.kotlin.srcDir(dir) }
@@ -246,9 +236,8 @@ fun decideOutputs(
             }
             val tcs = TargetConfigSource(
                 name = source.name,
-                configFile = TargetConfigFileImpl(
+                configFile = TargetConfigInput(
                     targetName = TargetName(source.name, source.type.toPlatformType()),
-                    outputDirectory = outputDirectory.subdirAsFile(targetSourceSet.name),
                     config = targetConfigs[source.name] ?: targetConfigs.getValue(COMMON_SOURCESET_NAME).copy(),
                 ),
                 registerSourceDir = { dir -> targetSourceSet.kotlin.srcDir(dir) }
@@ -276,14 +265,6 @@ internal fun Project.findFlavor(): String {
         DEFAULT_FLAVOR
     }
 }
-
-/**
- * Eagerly resolves a named subdirectory of this directory provider as a [File]. The eager
- * resolution is intentional — the result is captured as a task input at configuration time
- * so that downstream tasks can pick it up via the source-set Provider chain.
- */
-private fun Provider<Directory>.subdirAsFile(name: String): File =
-    map { it.dir(name) }.get().asFile
 
 internal fun Logger.toBuildKonfigLogger(): BuildKonfigLogger {
     return BuildKonfigLogger { level, message ->

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpec.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigSpec.kt
@@ -3,17 +3,15 @@ package com.codingfeline.buildkonfig.gradle
 import com.codingfeline.buildkonfig.compiler.BuildKonfigLogger
 import com.codingfeline.buildkonfig.compiler.FieldSpec
 import com.codingfeline.buildkonfig.compiler.TargetConfig
-import com.codingfeline.buildkonfig.compiler.TargetConfigFile
 import com.codingfeline.buildkonfig.compiler.TargetName
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Internal
-import java.io.File
+import java.io.Serializable
 
 data class TargetConfigSource(
     val name: String,
-    val configFile: TargetConfigFileImpl,
+    val configFile: TargetConfigInput,
     /**
      * Wires the generated source directory into the appropriate Kotlin source set.
      * Encapsulated as a callback so the call site does not need to know whether the
@@ -23,11 +21,15 @@ data class TargetConfigSource(
     val registerSourceDir: (Provider<Directory>) -> Unit,
 )
 
-data class TargetConfigFileImpl(
-    @Input override val targetName: TargetName,
-    @Internal override val outputDirectory: File,
-    @Input override val config: TargetConfig?
-) : TargetConfigFile
+/**
+ * Per-target task input. The output directory each target writes into is derived at task
+ * action time from `BuildKonfigTask.outputDirectory`, so it is not part of the cache key
+ * captured here.
+ */
+data class TargetConfigInput(
+    @get:Input val targetName: TargetName,
+    @get:Input val config: TargetConfig?,
+) : Serializable
 
 fun BuildKonfigExtension.mergeConfigs(
     logger: BuildKonfigLogger,

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
@@ -3,6 +3,9 @@ package com.codingfeline.buildkonfig.gradle
 import com.codingfeline.buildkonfig.VERSION
 import com.codingfeline.buildkonfig.compiler.BuildKonfigData
 import com.codingfeline.buildkonfig.compiler.BuildKonfigEnvironment
+import com.codingfeline.buildkonfig.compiler.TargetConfig
+import com.codingfeline.buildkonfig.compiler.TargetConfigFile
+import com.codingfeline.buildkonfig.compiler.TargetName
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.MapProperty
@@ -12,6 +15,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 
 const val FLAVOR_PROPERTY = "buildkonfig.flavor"
 
@@ -48,7 +52,7 @@ abstract class BuildKonfigTask : DefaultTask() {
     abstract val commonSourceSetName: Property<String>
 
     @get:Nested
-    abstract val targetConfigFiles: MapProperty<String, TargetConfigFileImpl>
+    abstract val targetConfigFiles: MapProperty<String, TargetConfigInput>
 
     /**
      * Root directory containing all generated BuildKonfig sources, with one subdirectory
@@ -66,19 +70,38 @@ abstract class BuildKonfigTask : DefaultTask() {
         // Gradle does not auto-clean `@OutputDirectory` content for ad-hoc tasks, so we
         // wipe the root explicitly. On cache hits the action does not run and Gradle
         // performs the cleanup + restore itself.
-        outputDirectory.get().asFile.deleteRecursively()
+        val outputRoot = outputDirectory.get().asFile
+        outputRoot.deleteRecursively()
 
         val commonName = commonSourceSetName.get()
-        val configFiles = targetConfigFiles.get()
+        val resolvedConfigs = targetConfigFiles.get().mapValues { (name, input) ->
+            ResolvedTargetConfigFile(
+                targetName = input.targetName,
+                outputDirectory = outputRoot.resolve(name),
+                config = input.config,
+            )
+        }
         val data = BuildKonfigData(
             packageName = packageName.get(),
             objectName = objectName.get(),
             exposeObject = exposeObject.get(),
-            commonConfig = configFiles.getValue(commonName),
-            targetConfigs = configFiles.filter { it.key != commonName }.values.toList(),
+            commonConfig = resolvedConfigs.getValue(commonName),
+            targetConfigs = resolvedConfigs.filter { it.key != commonName }.values.toList(),
             hasJsTarget = hasJsTarget.get()
         )
 
         BuildKonfigEnvironment(data).generateConfigs(logger.toBuildKonfigLogger())
     }
 }
+
+/**
+ * Compiler-facing [TargetConfigFile] built fresh for each task action by combining a
+ * [TargetConfigInput] with a sub-path of `BuildKonfigTask.outputDirectory`. Kept private
+ * to the task: it never participates in cache-key snapshotting or configuration cache
+ * serialization (those are handled by `TargetConfigInput`).
+ */
+private data class ResolvedTargetConfigFile(
+    override val targetName: TargetName,
+    override val outputDirectory: File,
+    override val config: TargetConfig?,
+) : TargetConfigFile


### PR DESCRIPTION
## Summary

Resolves #311. `TargetConfigFileImpl` is renamed to `TargetConfigInput` and slimmed down to the cache-key inputs only (`@Input targetName`, `@Input config`). The per-target `outputDirectory: File` that used to be eagerly resolved at configuration time is now derived inside `@TaskAction` from `BuildKonfigTask.outputDirectory.resolve(name)` and wrapped in a private `ResolvedTargetConfigFile` data class for the compiler call.

The follow-on cleanup the parameter-sprawl review on #310 flagged drops out for free:

- `subdirAsFile` extension helper — removed.
- `outputDirectory: Provider<Directory>` parameter threaded into `configureMultiplatform` / `configureSinglePlatform` / `decideOutputs` — removed.
- The local `outputDirectory` Provider in `configure()` is inlined directly into `task.outputDirectory.set(...)`.

`BuildKonfigTask.outputDirectory` is now the unambiguous source of truth: the rooted `Provider<Directory>` is set once and the task is the only thing that resolves per-target sub-paths.

### Cache & CC

- `TargetConfigInput : Serializable` keeps configuration cache compatibility (the previous impl was Serializable transitively via `TargetConfigFile`).
- The dropped `outputDirectory: File` was `@Internal`, so cache-key semantics are unchanged.
- Annotation site moves from `@Input` (constructor `val`) to `@get:Input` to match the rest of the gradle module's `@Nested` types.

## Test plan

- [x] `./gradlew clean build` — all gradle plugin tests pass, including `BuildKonfigPluginConfigurationCacheTest` and `BuildKonfigPluginGradle9KspTest`.
- [x] `./gradlew -p sample build` / `./gradlew -p sample-kts build` — both samples compile across `compileKotlin{Jvm,JsCommon,IosArm64,IosX64,IosSimulatorArm64,MacosArm64,LinuxX64,MingwX64}` and the new commonMain / desktopMain consumers introduced in #310 still resolve. (Yarn lock files were refreshed via `kotlinUpgradeYarnLock` to clear a stale `kotlinStoreYarnLock` failure unrelated to this PR.)
- [x] `./gradlew publishAllPublicationsToTestMavenRepository -PRELEASE_SIGNING_ENABLED=false`.

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)