### PR TITLE
ci: use GitHub App token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,14 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0
         id: release
         with:
-          token: ${{ secrets.WORKFLOW_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Replace the long-lived `WORKFLOW_TOKEN` PAT with a short-lived GitHub App installation token generated via `actions/create-github-app-token@v3.1.1` (SHA-pinned).
- Tokens minted by the action are scoped to this repository and expire after one hour, narrowing the blast radius if a workflow run is compromised.

## Required repository secrets
Before merging, configure the following Actions secrets (the old `WORKFLOW_TOKEN` can be removed after the first successful run):

- `RELEASE_PLEASE_CLIENT_ID` — the GitHub App's Client ID (the `Iv23li...` string from the App settings page, **not** the numeric App ID).
- `RELEASE_PLEASE_APP_PRIVATE_KEY` — the contents of the App's private-key `.pem` file.

The GitHub App needs these repository permissions:
- **Contents**: Read & write
- **Pull requests**: Read & write
- **Issues**: Read & write (only if release-please applies labels)

## Test plan
- [ ] Create / install the GitHub App and add the two secrets above
- [ ] Merge this PR and confirm the next push to `master` triggers `release-please` successfully and opens / updates the release PR under the App's bot identity
- [ ] After verification, delete the legacy `WORKFLOW_TOKEN` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)