### PR TITLE
fix: move generated sources to build/generated/source/buildkonfig

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -16,7 +16,7 @@ Do **not** import `com.google.common.truth.Truth` and call `Truth.assertThat(...
 
 ### Common scaffolding
 
-For Gradle TestKit-driven tests, extend `BaseGradlePluginTest` and rely on the helpers in `TestUtils.kt` (`gradleRunner()`, `TemporaryFolder.buildKonfigDir()`, `BuildResult.assertBuildSuccessful()`, `buildKonfigFile()`) instead of repeating the inlined `GradleRunner.create().withProjectDir(...).withPluginClasspath()` chain or `File(projectDir.root, "build/buildkonfig").also { it.deleteRecursively() }` pattern.
+For Gradle TestKit-driven tests, extend `BaseGradlePluginTest` and rely on the helpers in `TestUtils.kt` (`gradleRunner()`, `TemporaryFolder.buildKonfigDir()`, `BuildResult.assertBuildSuccessful()`, `buildKonfigFile()`) instead of repeating the inlined `GradleRunner.create().withProjectDir(...).withPluginClasspath()` chain or `File(projectDir.root, "build/generated/source/buildkonfig").also { it.deleteRecursively() }` pattern.
 
 ### Build script header
 

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -23,7 +23,12 @@ const val DEFAULT_FLAVOR: Flavor = ""
 const val COMMON_SOURCESET_NAME = "commonMain"
 const val MAIN_SOURCESET_NAME = "main"
 
-private const val OUTPUT_DIR_NAME = "buildkonfig"
+// Generated sources live under `build/generated/source/buildkonfig`, following the
+// convention shared by KSP, SQLDelight, and Apollo. The previous `build/buildkonfig`
+// location overlapped with paths AGP 9.0+ scans for baseline-profile inputs
+// (`prepareAndroidMainArtProfile`), causing Gradle's strict input/output overlap
+// validation to fail with an implicit-dependency error.
+private const val OUTPUT_DIR_NAME = "generated/source/buildkonfig"
 
 @Suppress("unused")
 abstract class BuildKonfigPlugin : Plugin<Project> {

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
@@ -56,7 +56,8 @@ abstract class BuildKonfigTask : DefaultTask() {
 
     /**
      * Root directory containing all generated BuildKonfig sources, with one subdirectory
-     * per source set (e.g. `build/buildkonfig/commonMain`, `build/buildkonfig/jvmMain`).
+     * per source set (e.g. `build/generated/source/buildkonfig/commonMain`,
+     * `build/generated/source/buildkonfig/jvmMain`).
      * Declared as a single `@OutputDirectory` so the entire subtree participates in the
      * cache key / restore cycle, and stale subdirectories from removed source sets
      * cannot leak through.

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/TestUtils.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/TestUtils.kt
@@ -6,11 +6,12 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.rules.TemporaryFolder
 import java.io.File
 
-const val BUILDKONFIG_BUILD_DIR = "build/buildkonfig"
+const val BUILDKONFIG_BUILD_DIR = "build/generated/source/buildkonfig"
 
 /**
- * Returns the (freshly cleaned) `build/buildkonfig` directory under [TemporaryFolder.getRoot].
- * Tests assert on files inside this directory, so they need a clean slate per run.
+ * Returns the (freshly cleaned) `build/generated/source/buildkonfig` directory under
+ * [TemporaryFolder.getRoot]. Tests assert on files inside this directory, so they need
+ * a clean slate per run.
  */
 fun TemporaryFolder.buildKonfigDir(): File =
     File(root, BUILDKONFIG_BUILD_DIR).also { it.deleteRecursively() }


### PR DESCRIPTION
## Summary

- Move BuildKonfig's task `@OutputDirectory` from `build/buildkonfig` to `build/generated/source/buildkonfig`.
- This aligns with the convention shared by KSP, SQLDelight, and Apollo, and removes the false overlap that triggered AGP 9.0's `prepareAndroidMainArtProfile` (`ProcessLibraryArtProfileTask`) input/output-overlap validation failure reported in #317.

## Why

The previous location overlapped with paths AGP 9.0+ scans for baseline-profile inputs. Gradle's strict input/output overlap validation then failed with an implicit-dependency error:

```
A problem was found with the configuration of task ':shared:prepareAndroidMainArtProfile' ...
Reason: Task ':shared:prepareAndroidMainArtProfile' uses this output of task ':shared:generateBuildKonfig' without declaring an explicit or implicit dependency.
```

By relocating outputs under `build/generated/source/buildkonfig`, the `@OutputDirectory` no longer subsumes any path AGP introspects.

Fixes #317

## Test plan

- [x] `./gradlew :buildkonfig-gradle-plugin:test` — full plugin test suite passes after `BUILDKONFIG_BUILD_DIR` was updated to the new path
- [x] `./gradlew -p sample generateBuildKonfig` — generates under `sample/build/generated/source/buildkonfig/{commonMain,desktopMain,iosMain,jsCommonMain,jvmMain}/`
- [x] `./gradlew -p sample-kts generateBuildKonfig` — same, under `sample-kts/build/generated/source/buildkonfig/...`
- [ ] Verified by reporter against a KMP+AGP 9.0 project