### PR TITLE
fix(plugin): scope BuildKonfigTask outputs to per-source-set leaves

### DIFF
--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -121,10 +121,19 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
             t.hasJsTarget.set(hasJsTarget)
             t.commonSourceSetName.set(COMMON_SOURCESET_NAME)
             t.targetConfigFiles.set(targetConfigSources.mapValues { (_, value) -> value.configFile })
+            // Populate per-source-set `@OutputDirectories` so each leaf — not the shared
+            // root — participates in cache-key snapshotting and task dependency inference.
+            targetConfigSources.keys.forEach { key ->
+                t.outputDirectories.put(key, t.outputDirectory.dir(key))
+            }
         }
 
         targetConfigSources.forEach { (key, configSource) ->
-            configSource.registerSourceDir(task.flatMap { it.outputDirectory.dir(key) })
+            // Route srcDir registration through `outputDirectories` (the tracked
+            // `@OutputDirectories` map) — not the `@Internal` root — so the Provider
+            // chain into the Kotlin source set carries the implicit task dependency
+            // that Gradle 9.x's strict validation requires.
+            configSource.registerSourceDir(task.flatMap { it.outputDirectories.getting(key) })
         }
     }
 
@@ -175,10 +184,11 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
             t.hasJsTarget.set(platformType == KotlinPlatformType.js)
             t.commonSourceSetName.set(MAIN_SOURCESET_NAME)
             t.targetConfigFiles.set(mapOf(MAIN_SOURCESET_NAME to targetConfigFile))
+            t.outputDirectories.put(MAIN_SOURCESET_NAME, t.outputDirectory.dir(MAIN_SOURCESET_NAME))
         }
 
         val mainSourceSet = kotlinExtension.sourceSets.getByName(MAIN_SOURCESET_NAME)
-        mainSourceSet.kotlin.srcDir(task.flatMap { it.outputDirectory.dir(MAIN_SOURCESET_NAME) })
+        mainSourceSet.kotlin.srcDir(task.flatMap { it.outputDirectories.getting(MAIN_SOURCESET_NAME) })
     }
 }
 

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
@@ -86,6 +86,11 @@ abstract class BuildKonfigTask : DefaultTask() {
         // [outputDirectories] (e.g. a target the user just removed) don't linger. The root
         // itself is `@Internal` — only the per-source-set leaves below participate in
         // Gradle's cache key / restore cycle — so this cleanup must happen explicitly here.
+        //
+        // Limitation: on a build-cache hit this action does not run; Gradle restores only
+        // the declared per-leaf `@OutputDirectories`. Orphan subdirectories left over from
+        // a previous non-cached run for a since-removed source set will persist on disk in
+        // that case. `./gradlew clean` clears them.
         val outputRoot = outputDirectory.get().asFile
         outputRoot.deleteRecursively()
 

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigTask.kt
@@ -7,13 +7,15 @@ import com.codingfeline.buildkonfig.compiler.TargetConfig
 import com.codingfeline.buildkonfig.compiler.TargetConfigFile
 import com.codingfeline.buildkonfig.compiler.TargetName
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
@@ -55,30 +57,44 @@ abstract class BuildKonfigTask : DefaultTask() {
     abstract val targetConfigFiles: MapProperty<String, TargetConfigInput>
 
     /**
-     * Root directory containing all generated BuildKonfig sources, with one subdirectory
-     * per source set (e.g. `build/generated/source/buildkonfig/commonMain`,
-     * `build/generated/source/buildkonfig/jvmMain`).
-     * Declared as a single `@OutputDirectory` so the entire subtree participates in the
-     * cache key / restore cycle, and stale subdirectories from removed source sets
-     * cannot leak through.
+     * Root directory beneath which per-source-set outputs live. Declared `@Internal`
+     * (not an output) because AGP 9+ `prepareAndroidMainArtProfile`
+     * (`ProcessLibraryArtProfileTask`) probes `<root>/baselineProfiles/baseline-prof.txt`
+     * for each generated source root it inherits from the Kotlin source set. If the
+     * root itself were an `@OutputDirectory`, Gradle's strict input/output overlap
+     * validation would reject the build with an "implicit dependency" error from
+     * `prepareAndroidMainArtProfile` to this task. The actual outputs are tracked via
+     * [outputDirectories], which list only the per-source-set leaves.
      */
-    @get:OutputDirectory
+    @get:Internal
     abstract val outputDirectory: DirectoryProperty
+
+    /**
+     * Per-source-set output directories — one entry per source set the merged config
+     * resolves to (e.g. `build/generated/source/buildkonfig/commonMain`,
+     * `.../jvmMain`). Each leaf matches the Kotlin source set's registered `srcDir`,
+     * and is the cache-key + task-dependency surface for downstream consumers
+     * (KSP, baseline profiles, ...).
+     */
+    @get:OutputDirectories
+    abstract val outputDirectories: MapProperty<String, Directory>
 
     @Suppress("unused")
     @TaskAction
     fun generateBuildKonfigFiles() {
-        // Gradle does not auto-clean `@OutputDirectory` content for ad-hoc tasks, so we
-        // wipe the root explicitly. On cache hits the action does not run and Gradle
-        // performs the cleanup + restore itself.
+        // Wipe the entire root so subdirectories from source sets that no longer appear in
+        // [outputDirectories] (e.g. a target the user just removed) don't linger. The root
+        // itself is `@Internal` — only the per-source-set leaves below participate in
+        // Gradle's cache key / restore cycle — so this cleanup must happen explicitly here.
         val outputRoot = outputDirectory.get().asFile
         outputRoot.deleteRecursively()
 
+        val outputs = outputDirectories.get()
         val commonName = commonSourceSetName.get()
         val resolvedConfigs = targetConfigFiles.get().mapValues { (name, input) ->
             ResolvedTargetConfigFile(
                 targetName = input.targetName,
-                outputDirectory = outputRoot.resolve(name),
+                outputDirectory = outputs.getValue(name).asFile,
                 config = input.config,
             )
         }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginAgpBaselineProfileTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginAgpBaselineProfileTest.kt
@@ -1,0 +1,84 @@
+package com.codingfeline.buildkonfig.gradle
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Regression test for issue #320: AGP 9.0+ `prepareAndroidMainArtProfile`
+ * (`ProcessLibraryArtProfileTask`) probes `<generatedSourceRoot>/baselineProfiles/baseline-prof.txt`
+ * for every generated source directory it inherits from the Kotlin source set.
+ *
+ * The task's `@OutputDirectory` must therefore be scoped tightly enough that
+ * `<root>/baselineProfiles/...` is not considered an output of `generateBuildKonfig`,
+ * otherwise Gradle 9.x rejects the build with:
+ *
+ *     Task ':...:prepareAndroidMainArtProfile' uses this output of task
+ *     ':...:generateBuildKonfig' without declaring an explicit or implicit dependency.
+ */
+class BuildKonfigPluginAgpBaselineProfileTest : BaseGradlePluginTest() {
+
+    private val androidBuildFileHeader =
+        buildFileHeader("kotlin-multiplatform", "com.android.kotlin.multiplatform.library")
+
+    @Test
+    fun `prepareAndroidMainArtProfile does not fail with implicit dependency error`() {
+        buildFile.writeText(
+            """
+            |$androidBuildFileHeader
+            |
+            |buildkonfig {
+            |    packageName = "com.sample"
+            |
+            |    defaultConfigs {
+            |        buildConfigField 'STRING', 'test', 'hoge'
+            |    }
+            |}
+            |
+            |kotlin {
+            |   android {
+            |       compileSdk = 28
+            |       minSdk = 21
+            |       namespace = "com.sample"
+            |   }
+            |   jvm()
+            |   iosX64()
+            |
+            |   sourceSets {
+            |     commonMain {
+            |       dependencies {}
+            |     }
+            |     androidMain {
+            |       dependencies {}
+            |     }
+            |   }
+            |}
+            """.trimMargin()
+        )
+
+        createAndroidManifest(projectDir)
+
+        // Force `compileAndroidMain` to have something to compile, exercising the
+        // generateBuildKonfig → compileAndroidMain dependency edge through the
+        // androidMain Kotlin source set's srcDirs.
+        projectDir.newFolder("src", "androidMain", "kotlin")
+        projectDir.newFile("src/androidMain/kotlin/Sample.kt").writeText(
+            """
+            |package com.sample
+            |
+            |object Sample
+            """.trimMargin()
+        )
+
+        projectDir.buildKonfigDir()
+
+        val result = gradleRunner(projectDir)
+            .withArguments("assembleAndroidMain", "--stacktrace")
+            .build()
+            .assertBuildSuccessful()
+
+        // The exact validation error message from Gradle 9.x must not surface.
+        assertThat(result.output)
+            .doesNotContain("without declaring an explicit or implicit dependency")
+        assertThat(result.output).contains("generateBuildKonfig")
+    }
+}

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginAgpBaselineProfileTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginAgpBaselineProfileTest.kt
@@ -1,6 +1,7 @@
 package com.codingfeline.buildkonfig.gradle
 
 import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Test
 
 /**
@@ -72,6 +73,12 @@ class BuildKonfigPluginAgpBaselineProfileTest : BaseGradlePluginTest() {
         projectDir.buildKonfigDir()
 
         val result = gradleRunner(projectDir)
+            // Pin to a Gradle 9.x release so the strict input/output overlap validation
+            // (the rule whose absence this test is guarding against) is always exercised
+            // regardless of the runtime Gradle TestKit happens to default to. AGP 9.2.x
+            // — the version used by this fixture's `com.android.kotlin.multiplatform.library`
+            // plugin — requires Gradle 9.4.1 or newer, so we pin to 9.4.1.
+            .withGradleVersion("9.4.1")
             .withArguments("assembleAndroidMain", "--stacktrace")
             .build()
             .assertBuildSuccessful()
@@ -79,6 +86,13 @@ class BuildKonfigPluginAgpBaselineProfileTest : BaseGradlePluginTest() {
         // The exact validation error message from Gradle 9.x must not surface.
         assertThat(result.output)
             .doesNotContain("without declaring an explicit or implicit dependency")
-        assertThat(result.output).contains("generateBuildKonfig")
+        // generateBuildKonfig must have actually been included in the task graph
+        // (i.e. its srcDir is correctly wired into the androidMain Kotlin source set).
+        val outcome = result.task(":generateBuildKonfig")?.outcome
+        assertThat(outcome).isAnyOf(
+            TaskOutcome.SUCCESS,
+            TaskOutcome.FROM_CACHE,
+            TaskOutcome.UP_TO_DATE,
+        )
     }
 }

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConfigurationCacheTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConfigurationCacheTest.kt
@@ -1,6 +1,7 @@
 package com.codingfeline.buildkonfig.gradle
 
 import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Test
 
 class BuildKonfigPluginConfigurationCacheTest : BaseGradlePluginTest() {
@@ -73,5 +74,77 @@ class BuildKonfigPluginConfigurationCacheTest : BaseGradlePluginTest() {
             .build()
 
         assertThat(secondRun.output).contains("Configuration cache entry reused")
+    }
+
+    /**
+     * The task dependency edge from a downstream Kotlin compile task back to
+     * `generateBuildKonfig` flows through the `MapProperty.getting(key)` Provider chain
+     * registered on the Kotlin source set. This test exercises that chain end-to-end
+     * under `--configuration-cache` to catch any regression in CC serialization of
+     * `@OutputDirectories MapProperty<String, Directory>`.
+     */
+    @Test
+    fun `compileKotlinJvm exercises the source set Provider chain under Configuration Cache`() {
+        buildFile.writeText(
+            """
+            |$buildFileHeader
+            |
+            |buildkonfig {
+            |   packageName = "com.sample"
+            |
+            |   defaultConfigs {
+            |       buildConfigField 'STRING', 'test', 'hoge'
+            |   }
+            |}
+            |
+            |$buildFileKMPConfig
+            """.trimMargin()
+        )
+
+        // A dummy source so that compileKotlinJvm has something to compile, forcing the
+        // Provider chain from jvmMain.kotlin.srcDirs through to generateBuildKonfig to
+        // be walked when Gradle builds the task graph.
+        projectDir.newFolder("src", "jvmMain", "kotlin")
+        projectDir.newFile("src/jvmMain/kotlin/Sample.kt").writeText(
+            """
+            |package com.sample
+            |
+            |object Sample
+            """.trimMargin()
+        )
+
+        val runner = gradleRunner(projectDir)
+            .withGradleVersion("9.3.1")
+
+        val firstRun = runner
+            .withArguments(
+                "compileKotlinJvm",
+                "--configuration-cache",
+                "--configuration-cache-problems=fail",
+                "--stacktrace",
+            )
+            .build()
+            .assertBuildSuccessful()
+
+        assertThat(firstRun.output).contains("Configuration cache entry stored")
+        // generateBuildKonfig must be picked up as a transitive dependency of compileKotlinJvm.
+        assertThat(firstRun.task(":generateBuildKonfig")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+        val secondRun = runner
+            .withArguments(
+                "compileKotlinJvm",
+                "--configuration-cache",
+                "--configuration-cache-problems=fail",
+                "--stacktrace",
+            )
+            .build()
+            .assertBuildSuccessful()
+
+        assertThat(secondRun.output).contains("Configuration cache entry reused")
+        // On the second run the inputs are unchanged, so the task should be up-to-date.
+        assertThat(secondRun.task(":generateBuildKonfig")?.outcome).isAnyOf(
+            TaskOutcome.UP_TO_DATE,
+            TaskOutcome.FROM_CACHE,
+        )
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #320 — AGP 9+ `prepareAndroidMainArtProfile` (`ProcessLibraryArtProfileTask`) was rejected by Gradle 9's strict input/output overlap validation because `BuildKonfigTask` declared the shared root `build/generated/source/buildkonfig` as a single `@OutputDirectory`, and AGP probes `<root>/baselineProfiles/baseline-prof.txt` for every generated source root it inherits from the Kotlin source set.
- Narrows the declared outputs to per-source-set leaves so AGP's probe no longer overlaps anything Gradle is snapshotting, while keeping the same physical layout (`build/generated/source/buildkonfig/<sourceset>/...`) and the stale-cleanup behavior introduced by #310.

## What changed

- `BuildKonfigTask.outputDirectory` is now `@Internal` — the root stays the working directory but is no longer a tracked output.
- New `outputDirectories: MapProperty<String, Directory>` annotated with `@OutputDirectories` holds one entry per source set the merged config resolves to. These per-leaf entries are what downstream Kotlin compilations consume as a `srcDir`.
- Source-set wiring (KMP + standalone) routes through `task.flatMap { it.outputDirectories.getting(key) }`, so the Provider chain into the Kotlin source set still flows through a tracked output — this preserves Gradle's implicit-task-dependency inference for compile tasks, KSP, etc.
- TaskAction wipes the entire root before regenerating, so stale subdirectories from source sets the user just removed still get cleaned up at action execution time. On cache hits the action does not run and Gradle restores the per-leaf state itself.

## Why not revert #318 / use AGP variant API

- The output-path move in #318 was orthogonal — even back at `build/buildkonfig/`, AGP would probe `<root>/baselineProfiles/...` inside whatever root was declared as an `@OutputDirectory`. The fix has to scope the declared outputs, not the path.
- AGP's `androidComponents.onVariants { ... addGeneratedSourceDirectory(...) }` API would establish an explicit dependency for the Android variant, but it's Android-specific and doesn't help any other AGP-version / non-AGP path. Narrowing outputs is the smaller, more portable fix.

## Test plan

- [x] `./gradlew :buildkonfig-gradle-plugin:test` — full plugin test suite passes, including the new `BuildKonfigPluginAgpBaselineProfileTest` that applies `kotlin-multiplatform` + `com.android.kotlin.multiplatform.library` and runs `assembleAndroidMain`. The new test asserts the implicit-dependency error no longer surfaces and `generateBuildKonfig` still runs as a transitive dependency.
- [x] `./gradlew publishAllPublicationsToTestMavenRepository -PRELEASE_SIGNING_ENABLED=false`
- [x] `./gradlew -p sample generateBuildKonfig` — output layout unchanged at `sample/build/generated/source/buildkonfig/{commonMain,desktopMain,iosMain,jsCommonMain,jvmMain}/`.
- [x] `./gradlew -p sample-kts generateBuildKonfig` — same.
- [ ] Verified by reporter against a KMP+AGP 9 project.

Fixes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)