### PR TITLE
test(plugin): make the new CC test exercise the per-leaf jvmMain Provider chain

### DIFF
--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConfigurationCacheTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginConfigurationCacheTest.kt
@@ -85,6 +85,12 @@ class BuildKonfigPluginConfigurationCacheTest : BaseGradlePluginTest() {
      */
     @Test
     fun `compileKotlinJvm exercises the source set Provider chain under Configuration Cache`() {
+        // `targetConfigs.jvm` is required so `decideOutputs()` registers a `jvmMain`
+        // entry in `outputDirectories` in addition to `commonMain`. Without it the map
+        // is single-entry and `compileKotlinJvm` would only reach `generateBuildKonfig`
+        // through the commonMain srcDir wiring — the per-leaf jvmMain Provider chain
+        // (`task.flatMap { it.outputDirectories.getting("jvmMain") }`) we want to guard
+        // against CC regressions would not actually be walked.
         buildFile.writeText(
             """
             |$buildFileHeader
@@ -94,6 +100,12 @@ class BuildKonfigPluginConfigurationCacheTest : BaseGradlePluginTest() {
             |
             |   defaultConfigs {
             |       buildConfigField 'STRING', 'test', 'hoge'
+            |   }
+            |
+            |   targetConfigs {
+            |       jvm {
+            |           buildConfigField 'STRING', 'jvmOnly', 'x'
+            |       }
             |   }
             |}
             |


### PR DESCRIPTION
## Summary

Follow-up to #321 (Gradle re-review of the merged PR caught this).

The downstream-consumer Configuration Cache test added in #321 (`compileKotlinJvm exercises the source set Provider chain under Configuration Cache`) claimed to walk the `MapProperty.getting(\"jvmMain\")` Provider chain from `compileKotlinJvm` back to `generateBuildKonfig`. In practice it didn't, because its fixture only declared `defaultConfigs`:

- With a single-entry merged config, `decideOutputs()` in `BuildKonfigPlugin.kt` skips non-`commonMain` source sets (`targetConfigs.size == 1 && source.name != COMMON_SOURCESET_NAME`), so `outputDirectories` only contained `commonMain`.
- `compileKotlinJvm` still reached `generateBuildKonfig`, but the edge flowed through commonMain's srcDir wiring (commonMain is in `compileKotlinJvm`'s `allKotlinSourceSets`), not through the per-leaf jvmMain chain the test was supposed to guard.

Adding a `targetConfigs.jvm` block forces `decideOutputs()` to register a `jvmMain` entry alongside `commonMain`. The test now exercises a strictly stronger invariant:

- CC serialization of `@OutputDirectories MapProperty<String, Directory>` with **multiple** entries (not just one).
- The per-leaf jvmMain Provider chain (`task.flatMap { it.outputDirectories.getting(\"jvmMain\") }`) actually walked end-to-end under `--configuration-cache`.

## Test plan

- [x] `./gradlew :buildkonfig-gradle-plugin:test --tests \"...BuildKonfigPluginConfigurationCacheTest\"` — passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)