### PR TITLE
feat!: remove standalone Kotlin/JS plugin support to unblock Kotlin 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ BuildKonfig
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.codingfeline.buildkonfig/buildkonfig-gradle-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.codingfeline.buildkonfig/buildkonfig-gradle-plugin)
 
-BuildConfig for Kotlin Multiplatform, Kotlin/JVM, and Kotlin/JS projects.  
+BuildConfig for Kotlin Multiplatform and Kotlin/JVM projects.  
 It currently supports embedding values from gradle file.
 
 ## Table Of Contents
@@ -37,7 +37,7 @@ Rather I'd like to do it once.
 ### Requirements
 
 - Kotlin **2.1.0** or later
-- One of: Kotlin Multiplatform, Kotlin/JVM, or Kotlin/JS plugin applied to the project
+- One of: Kotlin Multiplatform or Kotlin/JVM plugin applied to the project (use Kotlin/JS via the KMP `js()` target)
 - Gradle 8 or later
 
 <a name="gradle-configuration"/>
@@ -304,8 +304,9 @@ internal actual object BuildKonfig {
 
 ### Non-multiplatform projects
 
-BuildKonfig also works on standalone Kotlin/JVM and Kotlin/JS projects.
-Apply `org.jetbrains.kotlin.jvm` or `org.jetbrains.kotlin.js` instead of multiplatform, and use the same `buildkonfig { ... }` block.
+BuildKonfig also works on standalone Kotlin/JVM projects.
+Apply `org.jetbrains.kotlin.jvm` instead of multiplatform, and use the same `buildkonfig { ... }` block.
+For Kotlin/JS, use the Kotlin Multiplatform plugin with a `js()` target — the standalone `org.jetbrains.kotlin.js` plugin was removed in Kotlin 2.4.0.
 
 <details open>
 <summary>Kotlin DSL</summary>
@@ -358,7 +359,7 @@ internal object BuildKonfig {
 }
 ```
 
-For Kotlin/JS projects, `@JsExport` is auto-added when `exposeObjectWithName` is set, exactly like the multiplatform path. The `defaultConfigs` block (including flavors) is fully supported. `targetConfigs` are not meaningful for a single-target project; if you declare them, a warning is logged and they are ignored.
+The `defaultConfigs` block (including flavors) is fully supported. `targetConfigs` are not meaningful for a single-target project; if you declare them, a warning is logged and they are ignored.
 
 <a name="product-flavor"/>
 

--- a/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
+++ b/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt
@@ -10,7 +10,6 @@ import com.codingfeline.buildkonfig.gradle.kotlin.sources
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
-import org.jetbrains.kotlin.gradle.dsl.KotlinJsProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
@@ -38,7 +37,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         val extension = target.extensions.create("buildkonfig", BuildKonfigExtension::class.java, target.logger)
 
-        // Detect any supported Kotlin plugin (multiplatform / jvm / js / android).
+        // Detect any supported Kotlin plugin (multiplatform / jvm / android).
         // KotlinBasePlugin is the common interface implemented by all Kotlin compiler
         // plugin wrappers, so this fires once for whichever Kotlin plugin the user applied.
         target.plugins.withType(KotlinBasePlugin::class.java) {
@@ -51,7 +50,7 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
             check(configured) {
                 "BuildKonfig Gradle plugin applied in project '${target.path}' " +
                     "but no supported Kotlin plugin was found. " +
-                    "Apply one of: kotlin-multiplatform, kotlin-jvm, or kotlin-js."
+                    "Apply one of: kotlin-multiplatform or kotlin-jvm."
             }
         }
     }
@@ -146,7 +145,6 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
 
         val platformType = when (kotlinExtension) {
             is KotlinJvmProjectExtension -> KotlinPlatformType.jvm
-            is KotlinJsProjectExtension -> KotlinPlatformType.js
             else -> {
                 project.logger.warn(
                     "BuildKonfig: unsupported Kotlin extension '${kotlinExtension::class.java.simpleName}'. " +
@@ -181,7 +179,9 @@ abstract class BuildKonfigPlugin : Plugin<Project> {
 
         task.configure { t ->
             t.flavor.set(flavor)
-            t.hasJsTarget.set(platformType == KotlinPlatformType.js)
+            // Standalone Kotlin/JS is no longer supported (kotlin-js plugin removed in Kotlin 2.4.0);
+            // the only non-KMP target here is JVM, which never needs @JsExport.
+            t.hasJsTarget.set(false)
             t.commonSourceSetName.set(MAIN_SOURCESET_NAME)
             t.targetConfigFiles.set(mapOf(MAIN_SOURCESET_NAME to targetConfigFile))
             t.outputDirectories.put(MAIN_SOURCESET_NAME, t.outputDirectory.dir(MAIN_SOURCESET_NAME))

--- a/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginNonKmpTest.kt
+++ b/buildkonfig-gradle-plugin/src/test/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPluginNonKmpTest.kt
@@ -7,7 +7,6 @@ import java.io.File
 class BuildKonfigPluginNonKmpTest : BaseGradlePluginTest() {
 
     private val jvmBuildFileHeader = buildFileHeader("org.jetbrains.kotlin.jvm")
-    private val jsBuildFileHeader = buildFileHeader("org.jetbrains.kotlin.js")
 
     @Test
     fun `Applying plugin to a Kotlin JVM project generates a single concrete object`() {
@@ -109,49 +108,6 @@ class BuildKonfigPluginNonKmpTest : BaseGradlePluginTest() {
     }
 
     @Test
-    fun `Applying plugin to a Kotlin JS project generates a single concrete object`() {
-        buildFile.writeText(
-            """
-            |$jsBuildFileHeader
-            |
-            |kotlin {
-            |   js {
-            |       browser()
-            |       nodejs()
-            |       binaries.executable()
-            |   }
-            |}
-            |
-            |buildkonfig {
-            |   packageName = "com.sample"
-            |   exposeObjectWithName = "BuildKonfig"
-            |
-            |   defaultConfigs {
-            |       buildConfigField 'STRING', 'env', 'production'
-            |   }
-            |}
-            """.trimMargin()
-        )
-
-        // kotlin-js requires a main entry point for the executable.
-        val srcDir = projectDir.newFolder("src", "main", "kotlin")
-        File(srcDir, "Main.kt").writeText("fun main() {}")
-
-        val buildDir = projectDir.buildKonfigDir()
-
-        gradleRunner(projectDir)
-            .withArguments("generateBuildKonfig", "--stacktrace")
-            .build()
-            .assertBuildSuccessful()
-
-        val generated = buildKonfigFile(buildDir, "main", "com.sample")
-        assertThat(generated.exists()).isTrue()
-        val content = generated.readText()
-        assertThat(content).contains("@JsExport")
-        assertThat(content).contains("public object BuildKonfig")
-    }
-
-    @Test
     fun `non-KMP JVM project is compatible with Configuration Cache`() {
         buildFile.writeText(
             """
@@ -166,57 +122,6 @@ class BuildKonfigPluginNonKmpTest : BaseGradlePluginTest() {
             |}
             """.trimMargin()
         )
-
-        val runner = gradleRunner(projectDir)
-
-        val firstRun = runner
-            .withArguments(
-                "generateBuildKonfig",
-                "--configuration-cache",
-                "--configuration-cache-problems=fail",
-                "--stacktrace",
-            )
-            .build()
-        assertThat(firstRun.output).contains("Configuration cache entry stored")
-
-        val secondRun = runner
-            .withArguments(
-                "generateBuildKonfig",
-                "--configuration-cache",
-                "--configuration-cache-problems=fail",
-                "--stacktrace",
-            )
-            .build()
-        assertThat(secondRun.output).contains("Configuration cache entry reused")
-    }
-
-    @Test
-    fun `non-KMP JS project is compatible with Configuration Cache`() {
-        buildFile.writeText(
-            """
-            |$jsBuildFileHeader
-            |
-            |kotlin {
-            |   js {
-            |       browser()
-            |       nodejs()
-            |       binaries.executable()
-            |   }
-            |}
-            |
-            |buildkonfig {
-            |   packageName = "com.sample"
-            |
-            |   defaultConfigs {
-            |       buildConfigField 'STRING', 'env', 'production'
-            |   }
-            |}
-            """.trimMargin()
-        )
-
-        // kotlin-js requires a main entry point for the executable.
-        val srcDir = projectDir.newFolder("src", "main", "kotlin")
-        File(srcDir, "Main.kt").writeText("fun main() {}")
 
         val runner = gradleRunner(projectDir)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 gradle = "9.4.1"
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 dokka = "2.2.0"
 android = "9.2.1"
 ksp = "2.3.9"


### PR DESCRIPTION
## Summary

Kotlin 2.4.0 raises the deprecation level of the standalone `org.jetbrains.kotlin.js` Gradle plugin (and its extension type `KotlinJsProjectExtension`) to **ERROR**. This made the `is KotlinJsProjectExtension ->` branch in `BuildKonfigPlugin` fail to compile, blocking the Kotlin 2.4.0 migration (Renovate PR #327).

Standalone Kotlin/JS consumers can no longer use the plugin under Kotlin 2.4.0 and must migrate to the KMP `js()` target anyway — a path BuildKonfig already supports — so the standalone JS branch is now dead code.

## Changes

- **`BuildKonfigPlugin.kt`**: remove the `import KotlinJsProjectExtension` and the `is KotlinJsProjectExtension -> KotlinPlatformType.js` branch in `configureSinglePlatform` (standalone JVM is kept). Since the only non-KMP target is now JVM, `hasJsTarget` is simplified to `false`, and the user-facing messages no longer mention kotlin-js.
- **`BuildKonfigPluginNonKmpTest.kt`**: drop the two standalone JS tests; JVM tests are kept.
- **`README.md`**: remove standalone Kotlin/JS mentions and direct Kotlin/JS users to the KMP `js()` target.
- **`gradle/libs.versions.toml`**: Kotlin `2.3.21` → `2.4.0`. KSP stays at `2.3.9` (compatible with 2.4.0).

The Gradle wrapper is already at 9.6.0 (#331); this combines with Kotlin 2.4.0 and builds with only KGP's "untested newer Gradle" warning.

## Verification

- `:buildkonfig-gradle-plugin:compileKotlin` succeeds — the `KotlinJsProjectExtension is deprecated` ERROR is resolved.
- 52 of 53 tests pass. The single failure (`BuildKonfigPluginAgpBaselineProfileTest`) is an environmental `SDK location not found` failure (no Android SDK installed locally), unrelated to this change.

Resolves #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)